### PR TITLE
Update transmission.json

### DIFF
--- a/transmission.json
+++ b/transmission.json
@@ -3,7 +3,7 @@
   "release": "11.1-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
   "pkgs": [
-    "net-p2p/transmission-daemon",
+    "net-p2p/transmission-daemon"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage",
   "fingerprints": {


### PR DESCRIPTION
JSON file is invalid, so when trying to install the plugin, iocage shows an error. "Invalid JSON file supplied, please supply a correctly formatted JSON file."
In line 6, delete the comma at the end.