### PR TITLE
Switch mineos to quarterly pkg

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -21,7 +21,7 @@
     "ftp/wget",
     "shells/bash"
       ],
-  "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/latest",
+  "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
   "fingerprints": {
 	  "plugin-default": [
 		  {


### PR DESCRIPTION
I want to switch the repo for the MineOS plugin from "latest" to "quarterly" in order to:

1.  increase stability
2. keep things consistent with standard a jail
Thanks!
