### PR TITLE
Add unificontroller LTS -

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -295,6 +295,14 @@
         "description": "The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations.",
         "official": false
   },
+ "unificontroller-lts": {
+        "MANIFEST": "unificontroller-lts.json",
+        "name": "unificontroller-lts",
+        "primary_pkg": "net-mgmt/unifi-lts",
+        "icon": "https://www.trueos.org/iocage-icons/unificontroller.png",
+        "description": "The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations. (Long term support version)",
+        "official": false
+  },
  "homebridge": {
 	"MANIFEST": "homebridge.json",
 	"name":	"Homebridge",

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -1,0 +1,18 @@
+{
+  "name": "unificontroller-lts",
+  "release": "11.2-RELEASE",
+  "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
+  "pkgs": [
+    "net-mgmt/unifi-lts"
+  ],
+  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+  "fingerprints": {
+	  "iocage-plugins": [
+		  {
+		  "function": "sha256",
+		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+	  }
+	  ]
+  },
+  "official": false
+}


### PR DESCRIPTION
As promised since there were no problems with primary version, @miwi-fbsd.

Note that it uses the same artifact, since there are no differences in configuration.
