### PR TITLE
Added Gitea Plugin.

### DIFF
--- a/gitea.json
+++ b/gitea.json
@@ -1,0 +1,22 @@
+{
+  "name": "gitea",
+  "plugin_schema": "2",
+  "release": "11.2-RELEASE",
+  "artifact": "https://github.com/jed-frey/iocage-plugin-gitea.git",
+  "pkgs": [
+    "www/nginx-lite",
+    "databases/mysql57-server",
+    "www/gitea",
+    "databases/redis"
+  ],
+  "packagesite": "http://pkg.freebsd.org/FreeBSD:11:amd64/latest",
+  "fingerprints": {
+	  "iocage-plugins": [
+		  {
+		  "function": "sha256",
+		  "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+	  }
+	  ]
+  },
+  "official": false
+}


### PR DESCRIPTION
More or less based around my [FreeNAS-Gitea v2.0](https://github.com/jed-frey/FreeNAS-Gitea) instructions.

Tested from the command line: ```iocage fetch -P -n gitea.json ip4_addr="lagg0|192.168.1.200/24"```

Should probably be tested by someone else.

- Sets up the MySQL backend of Gitea (rather than the default sqlite) and Redis as a cache.
- Puts Gitea itself behind NGNIX.
- Generates SSL certs and sets up NGINX to listen on 80 and 443, forwarding all HTTP to HTTPS.
