### PR TITLE
- Reenable vnet

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -22,7 +22,7 @@
 	"sysvmsg": "new",
 	"sysvsem": "new",
 	"sysvshm": "new",
-	"vnet": "off"
+	"vnet": "on"
   },
   "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
   "fingerprints": {


### PR DESCRIPTION
In order to enable dhcp support we need vnet on again. Please take note this can be only merged once the asigra plugin pr have been merge (will follow up on that)