### PR TITLE
Add missing pkg_name for dnsmasq plugin

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -315,6 +315,7 @@
 	"name": "Dnsmasq",
 	"icon": "https://www.trueos.org/iocage-icons/dnsmasq.png",
 	"description": "Dnsmasq provides network infrastructure for small networks: DNS, DHCP, router advertisement and network boot.",
-	"official": false
+	"official": false,
+	"primary_pkg": "dns/dnsmasq"
  }
 }


### PR DESCRIPTION
This commit adds a missing pkg_name for dnsmasq plugin.