### PR TITLE
Use port's origin name

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -74,7 +74,7 @@
   "nextcloud": {
         "MANIFEST": "nextcloud.json",
         "name": "Nextcloud",
-        "primary_pkg": "www/nextcloud-php56",
+        "primary_pkg": "www/nextcloud",
         "icon": "https://www.trueos.org/iocage-icons/nextcloud.png",
         "description": "Access, share and protect your files, calendars, contacts, communication & more at home and in your enterprise.",
         "official": true


### PR DESCRIPTION
This commit introduces changes to primary_pkg key of nextcloud plugin making sure we use port's origin name instead of specifying a flavour as well which will probably fail version retrieval.