### PR TITLE
Normalize pkg entries

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -282,7 +282,7 @@
  "sabnzbd": {
         "MANIFEST": "sabnzbd.json",
         "name": "sabnzbd",
-        "primary_pkg": "news/sabnzbdplus",
+        "primary_pkg": "sabnzbdplus",
         "icon": "https://www.trueos.org/iocage-icons/sabnzbd.png",
         "description": "SABnzbd is a cross-platform binary newsreader.",
         "official": true
@@ -290,7 +290,7 @@
  "unificontroller": {
         "MANIFEST": "unificontroller.json",
         "name": "unificontroller",
-        "primary_pkg": "net-mgmt/unifi5",
+        "primary_pkg": "unifi5",
         "icon": "https://www.trueos.org/iocage-icons/unificontroller.png",
         "description": "The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations.",
         "official": false
@@ -298,7 +298,7 @@
  "unificontroller-lts": {
         "MANIFEST": "unificontroller-lts.json",
         "name": "unificontroller-lts",
-        "primary_pkg": "net-mgmt/unifi-lts",
+        "primary_pkg": "unifi-lts",
         "icon": "https://www.trueos.org/iocage-icons/unificontroller.png",
         "description": "The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations. (Long term support version)",
         "official": false
@@ -316,6 +316,6 @@
 	"icon": "https://www.trueos.org/iocage-icons/dnsmasq.png",
 	"description": "Dnsmasq provides network infrastructure for small networks: DNS, DHCP, router advertisement and network boot.",
 	"official": false,
-	"primary_pkg": "dns/dnsmasq"
+	"primary_pkg": "dnsmasq"
  }
 }

--- a/INDEX
+++ b/INDEX
@@ -114,7 +114,7 @@
   "quasselcore": {
         "MANIFEST": "quasselcore.json",
         "name": "Quasselcore",
-        "primary_pkg": "irc/quassel-core",
+        "primary_pkg": "quassel-core",
         "icon": "https://www.trueos.org/iocage-icons/quasselcore.png",
         "description": "Quassel Core is a daemon/headless IRC client, part of Quassel, that supports 24/7 connectivity. Quassel Client can be attached to it to.",
         "official": true
@@ -122,7 +122,7 @@
   "subsonic": {
         "MANIFEST": "subsonic.json",
         "name": "SubSonic",
-        "primary_pkg": "www/subsonic-standalone",
+        "primary_pkg": "subsonic-standalone",
         "icon": "https://www.trueos.org/iocage-icons/subsonic.png",
         "description": "Open-source web-based media streamer and jukebox.",
         "official": true
@@ -130,7 +130,7 @@
   "madsonic": {
         "MANIFEST": "madsonic.json",
         "name": "MadSonic",
-        "primary_pkg": "www/madsonic-standalone",
+        "primary_pkg": "madsonic-standalone",
         "icon": "https://www.trueos.org/iocage-icons/madsonic.png",
         "description": "Open-source web-based media streamer and jukebox.",
         "official": true
@@ -138,7 +138,7 @@
   "syncthing": {
         "MANIFEST": "syncthing.json",
         "name": "Syncthing",
-        "primary_pkg": "net/syncthing",
+        "primary_pkg": "syncthing",
         "icon": "https://www.trueos.org/iocage-icons/syncthing.png",
         "description": "Personal cloud sync",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -146,7 +146,7 @@
   "deluge": {
         "MANIFEST": "deluge.json",
         "name": "Deluge",
-        "primary_pkg": "net-p2p/deluge-cli",
+        "primary_pkg": "deluge-cli",
         "icon": "https://www.trueos.org/iocage-icons/deluge.png",
         "description": "Bittorrent client using Python, and libtorrent-rasterbar",
         "official": true
@@ -154,7 +154,7 @@
   "sonarr": {
         "MANIFEST": "sonarr.json",
         "name": "Sonarr",
-        "primary_pkg": "net-p2p/sonarr",
+        "primary_pkg": "sonarr",
         "icon": "https://www.trueos.org/iocage-icons/sonarr.png",
         "description": "PVR for Usenet and BitTorrent users",
         "official": true
@@ -162,7 +162,7 @@
   "transmission": {
         "MANIFEST": "transmission.json",
         "name": "Transmission",
-        "primary_pkg": "net-p2p/transmission-daemon",
+        "primary_pkg": "transmission-daemon",
         "icon": "https://www.trueos.org/iocage-icons/transmission.png",
         "description": "Fast and lightweight daemon BitTorrent client",
         "official": true
@@ -186,7 +186,7 @@
   "tarsnap": {
         "MANIFEST": "tarsnap.json",
         "name": "Tarsnap",
-        "primary_pkg": "sysutils/tarsnap",
+        "primary_pkg": "tarsnap",
         "icon": "https://www.trueos.org/iocage-icons/tarsnap.png",
         "description": "Online encrypted backup service (client)",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -42,7 +42,7 @@
   "gitlab": {
         "MANIFEST": "gitlab.json",
         "name": "GitLab",
-        "primary_pkg": "www/gitlab-ce",
+        "primary_pkg": "gitlab-ce",
         "icon": "https://www.trueos.org/iocage-icons/gitlab.png",
         "description": "Powerful features for modern software development",
         "official": true
@@ -50,7 +50,7 @@
   "gitlab-runner": {
         "MANIFEST": "gitlab-runner.json",
         "name": "GitLab Runner",
-        "primary_pkg": "devel/gitlab-runner",
+        "primary_pkg": "gitlab-runner",
         "icon": "https://www.trueos.org/iocage-icons/gitlab.png",
         "description": "CI/CD runner powered by gitlab",
         "official": false
@@ -58,7 +58,7 @@
   "jenkins": {
         "MANIFEST": "jenkins.json",
         "name": "Jenkins",
-        "primary_pkg": "devel/jenkins",
+        "primary_pkg": "jenkins",
         "icon": "https://www.trueos.org/iocage-icons/jenkins.png",
         "description": "Jenkins CI",
         "official": true
@@ -66,7 +66,7 @@
   "jenkins-lts": {
         "MANIFEST": "jenkins-lts.json",
         "name": "Jenkins (LTS)",
-        "primary_pkg": "devel/jenkins-lts",
+        "primary_pkg": "jenkins-lts",
         "icon": "https://www.trueos.org/iocage-icons/jenkins.png",
         "description": "Jenkins CI (Long Term Support Version)",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -74,7 +74,7 @@
   "nextcloud": {
         "MANIFEST": "nextcloud.json",
         "name": "Nextcloud",
-        "primary_pkg": "www/nextcloud",
+        "primary_pkg": "nextcloud-php71",
         "icon": "https://www.trueos.org/iocage-icons/nextcloud.png",
         "description": "Access, share and protect your files, calendars, contacts, communication & more at home and in your enterprise.",
         "official": true
@@ -82,7 +82,7 @@
   "openvpn": {
         "MANIFEST": "openvpn.json",
         "name": "OpenVPN Server",
-        "primary_pkg": "security/openvpn",
+        "primary_pkg": "openvpn",
         "icon": "http://swupdate.openvpn.net/community/icons/ovpntech_key.png",
         "description": "OpenVPN server",
         "official": false
@@ -90,7 +90,7 @@
   "plexmediaserver": {
         "MANIFEST": "plexmediaserver.json",
         "name": "Plex Media Server",
-        "primary_pkg": "multimedia/plexmediaserver",
+        "primary_pkg": "plexmediaserver",
         "icon": "https://www.trueos.org/iocage-icons/plex.png",
         "description": "The Plex media server system",
         "official": true
@@ -98,7 +98,7 @@
   "redmine": {
         "MANIFEST": "redmine.json",
         "name": "Redmine",
-        "primary_pkg": "www/redmine",
+        "primary_pkg": "redmine",
         "icon": "https://www.trueos.org/iocage-icons/redmine.png",
         "description": "Redmine Bugtracker",
         "official": true
@@ -106,7 +106,7 @@
   "plexmediaserver-plexpass": {
         "MANIFEST": "plexmediaserver-plexpass.json",
         "name": "Plex Media Server (PlexPass)",
-        "primary_pkg": "multimedia/plexmediaserver-plexpass",
+        "primary_pkg": "plexmediaserver-plexpass",
         "icon": "https://www.trueos.org/iocage-icons/plex.png",
         "description": "The Plex media server system",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -242,7 +242,7 @@
   "weechat": {
         "MANIFEST": "weechat.json",
         "name": "weechat",
-        "primary_pkg": "irc/weechat",
+        "primary_pkg": "weechat",
         "icon": "https://www.trueos.org/iocage-icons/weechat.png",
         "description": "WeeChat (Wee Enhanced Environment for Chat) is a fast and light IRC client.",
         "official": true
@@ -250,7 +250,7 @@
  "irssi": {
         "MANIFEST": "irssi.json",
         "name": "irssi",
-        "primary_pkg": "irc/irssi",
+        "primary_pkg": "irssi",
         "icon": "https://www.trueos.org/iocage-icons/irssi.png",
         "description": "Irssi is a modular IRC client that currently has only text mode user interface, but 80-90% of the code isn't text mode specific, so other UIs could be created pretty easily.",
         "official": true
@@ -258,7 +258,7 @@
  "zoneminder": {
         "MANIFEST": "zoneminder.json",
         "name": "Zoneminder",
-        "primary_pkg": "multimedia/zoneminder",
+        "primary_pkg": "zoneminder",
         "icon": "https://www.trueos.org/iocage-icons/zoneminder.png",
         "description": "ZoneMinder is a free, open source Closed-circuit television software application developed for Linux which supports IP, USB and Analog cameras.",
         "official": true
@@ -266,7 +266,7 @@
  "radarr": {
         "MANIFEST": "radarr.json",
         "name": "radarr",
-        "primary_pkg": "net-p2p/radarr",
+        "primary_pkg": "radarr",
         "icon": "https://www.trueos.org/iocage-icons/radarr.png",
         "description": "Radarr is a fork of Sonarr to work with movies in the style of Couchpotato.",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -210,7 +210,7 @@
    "ttrss": {
         "MANIFEST": "ttrss.json",
         "name": "TinyTinyRSS",
-        "primary_pkg": "www/tt-rss",
+        "primary_pkg": "tt-rss",
         "icon": "https://www.trueos.org/iocage-icons/ttrss.png",
         "description": "Open source web-based news feed (RSS/Atom) aggregator, designed to allow you to read news from any location.",
         "official": true
@@ -218,7 +218,7 @@
    "bacula-server": {
         "MANIFEST": "bacula-server.json",
         "name": "Bacula-server",
-        "primary_pkg": "sysutils/bacula9-server",
+        "primary_pkg": "bacula9-server",
         "icon": "https://www.trueos.org/iocage-icons/bacula-server.png",
         "description": "programs to manage backup, recovery, and verification of computer data across a network of computers of different kinds",
         "official": true
@@ -226,7 +226,7 @@
    "xmrig": {
         "MANIFEST": "xmrig.json",
         "name": "XMRig",
-        "primary_pkg": "net-p2p/xmrig",
+        "primary_pkg": "xmrig",
         "icon": "https://www.trueos.org/iocage-icons/xmrig.png",
         "description": "XMRig is a high performance Monero (XMR) CPU miner written in C++.",
         "official": true
@@ -234,7 +234,7 @@
   "qbittorrent": {
         "MANIFEST": "qbittorrent.json",
         "name": "qbittorrent",
-        "primary_pkg": "net-p2p/qbittorrent",
+        "primary_pkg": "qbittorrent-nox",
         "icon": "https://www.trueos.org/iocage-icons/qbittorrent.png",
         "description": "qBittorrent is the open source bittorrent client in C++/Qt that uses libtorrent-rasterbar.",
         "official": true

--- a/INDEX
+++ b/INDEX
@@ -2,7 +2,7 @@
   "rslsync": {
         "MANIFEST": "rslsync.json",
         "name": "Resilio Sync",
-        "primary_pkg": "net-p2p/rslsync",
+        "primary_pkg": "rslsync",
         "icon": "https://www.trueos.org/iocage-icons/btsync.png",
         "description": "Resilient, fast and scalable file sync software for enterprises and individuals.",
         "official": true
@@ -10,7 +10,7 @@
   "backuppc": {
         "MANIFEST": "backuppc.json",
         "name": "BackupPC",
-        "primary_pkg": "sysutils/backuppc4",
+        "primary_pkg": "backuppc4",
         "icon": "https://www.trueos.org/iocage-icons/backuppc.png",
         "description": "BackupPC is a high-performance, enterprise-grade system for backing up Linux, WinXX and MacOSX PCs and laptops to a server's disk.",
         "official": true
@@ -18,7 +18,7 @@
   "clamav": {
         "MANIFEST": "clamav.json",
         "name": "ClamAV",
-        "primary_pkg": "security/clamav",
+        "primary_pkg": "clamav",
         "icon": "https://www.trueos.org/iocage-icons/clamav.png",
         "description": "ClamAV® is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats.",
         "official": true
@@ -26,7 +26,7 @@
   "couchpotato": {
         "MANIFEST": "couchpotato.json",
         "name": "CouchPotato",
-        "primary_pkg": "net-p2p/couchpotato",
+        "primary_pkg": "couchpotato",
         "icon": "https://www.trueos.org/iocage-icons/couchpotato.png",
         "description": "CouchPotato is an automatic NZB and torrent downloader.",
         "official": true
@@ -34,7 +34,7 @@
   "emby": {
         "MANIFEST": "emby.json",
         "name": "Emby",
-        "primary_pkg": "multimedia/emby-server",
+        "primary_pkg": "emby-server",
         "icon": "https://www.trueos.org/iocage-icons/emby.png",
         "description": "Home media server built using mono and other open source technologies",
         "official": true

--- a/backuppc.json
+++ b/backuppc.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
   "pkgs": [
-    "sysutils/backuppc4",
-    "www/apache24"	  
+    "backuppc4",
+    "apache24"	  
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/bacula-server.json
+++ b/bacula-server.json
@@ -3,9 +3,9 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-bacula-server.git",
   "pkgs": [
-    "sysutils/bacula9-server",
-    "databases/postgresql95-server",
-    "databases/postgresql95-contrib"
+    "bacula9-server",
+    "postgresql95-server",
+    "postgresql95-contrib"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/clamav.json
+++ b/clamav.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
   "pkgs": [
-    "security/clamav"
+    "clamav"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
   "pkgs": [
-    "net-p2p/couchpotato"
+    "couchpotato"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/deluge.json
+++ b/deluge.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-deluge.git",
   "pkgs": [
-    "net-p2p/deluge-cli"
+    "deluge-cli"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -4,8 +4,8 @@
 	"release": "11.2-RELEASE",
 	"artifact": "https://github.com/timsavage/iocage-plugin-dnsmasq.git",
 	"pkgs": [
-	   "dns/dnsmasq",
-	   "lang/python36"
+	   "dnsmasq",
+	   "python36"
 	],
 	"packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
 	"fingerprints": {

--- a/emby.json
+++ b/emby.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
   "pkgs": [
-    "multimedia/emby-server",
-    "multimedia/ffmpeg"
+    "emby-server",
+    "ffmpeg"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/gitlab-runner.json
+++ b/gitlab-runner.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbivens/iocage-plugin-gitlab-runner.git",
   "pkgs": [
-    "devel/gitlab-runner"
+    "gitlab-runner"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/gitlab.json
+++ b/gitlab.json
@@ -3,10 +3,10 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-gitlab.git",
   "pkgs": [
-    "www/gitlab-ce",
-    "databases/postgresql95-server",
-    "databases/postgresql95-contrib",
-    "www/nginx"
+    "gitlab-ce",
+    "postgresql95-server",
+    "postgresql95-contrib",
+    "nginx"
   ],
   "properties": {
      "allow_sysvipc": "1"

--- a/irssi.json
+++ b/irssi.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-irssi.git",
   "pkgs": [
-    "irc/irssi"
+    "irssi"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
   "pkgs": [
-    "devel/jenkins-lts",
-    "www/nginx"
+    "jenkins-lts",
+    "nginx"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/jenkins.json
+++ b/jenkins.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
   "pkgs": [
-    "devel/jenkins",
-    "www/nginx"
+    "jenkins",
+    "nginx"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/madsonic.json
+++ b/madsonic.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
   "pkgs": [
-    "www/madsonic-standalone"
+    "madsonic-standalone"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -3,9 +3,9 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
   "pkgs": [
-    "www/nextcloud",
-    "www/nginx",
-    "databases/mysql56-server"
+    "nextcloud-php71",
+    "nginx",
+    "mysql56-server"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/openvpn.json
+++ b/openvpn.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/gitbulb/iocage-plugin-openvpn.git",
   "pkgs": [
-    "security/openvpn"
+    "openvpn"
   ],
   "properties": {
     "allow_raw_sockets": "1",

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
   "pkgs": [
-    "multimedia/plexmediaserver-plexpass",
-    "multimedia/ffmpeg"
+    "plexmediaserver-plexpass",
+    "ffmpeg"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
   "pkgs": [
-    "multimedia/plexmediaserver",
-    "multimedia/ffmpeg"
+    "plexmediaserver",
+    "ffmpeg"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -6,7 +6,7 @@
     "vnet":"on"
   },
   "pkgs": [
-    "net-p2p/qbittorrent"
+    "qbittorrent-nox"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/quasselcore.json
+++ b/quasselcore.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-quassel.git",
   "pkgs": [
-    "irc/quassel-core"
+    "quassel-core"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/radarr.json
+++ b/radarr.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
   "pkgs": [
-    "net-p2p/radarr"
+    "radarr"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/redmine.json
+++ b/redmine.json
@@ -3,9 +3,9 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-redmine.git",
   "pkgs": [
-    "www/redmine",
-    "www/nginx",
-    "databases/mysql56-server"
+    "redmine",
+    "nginx",
+    "mysql56-server"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/rslsync.json
+++ b/rslsync.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-btsync.git",
   "pkgs": [
-    "net-p2p/rslsync"
+    "rslsync"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/sabnzbd.json
+++ b/sabnzbd.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-sabnzbd",
   "pkgs": [
-    "news/sabnzbdplus"
+    "sabnzbdplus"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/sonarr.json
+++ b/sonarr.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-sonarr.git",
   "pkgs": [
-    "net-p2p/sonarr"
+    "sonarr"
   ],
   "properties": {
      "allow_sysvipc": "1"

--- a/subsonic.json
+++ b/subsonic.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-subsonic.git",
   "pkgs": [
-    "www/subsonic-standalone"
+    "subsonic-standalone"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/syncthing.json
+++ b/syncthing.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
   "pkgs": [
-    "net/syncthing",
-    "www/nginx"
+    "syncthing",
+    "nginx"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
   "pkgs": [
-    "sysutils/tarsnap"
+    "tarsnap"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/transmission.json
+++ b/transmission.json
@@ -3,8 +3,8 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
   "pkgs": [
-    "net-p2p/transmission-daemon",
-    "www/transmission-web"	  
+    "transmission-daemon",
+    "transmission-web"	  
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/ttrss.json
+++ b/ttrss.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-ttrss",
   "pkgs": [
-    "www/tt-rss"
+    "tt-rss"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
   "pkgs": [
-    "net-mgmt/unifi-lts"
+    "unifi-lts"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
   "pkgs": [
-    "net-mgmt/unifi5"
+    "unifi5"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/weechat.json
+++ b/weechat.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-weechat.git",
   "pkgs": [
-    "irc/weechat"
+    "weechat"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/xmrig.json
+++ b/xmrig.json
@@ -3,7 +3,7 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-xmrig.git",
   "pkgs": [
-    "net-p2p/xmrig"
+    "xmrig"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -3,10 +3,10 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-zoneminder",
   "pkgs": [
-    "multimedia/zoneminder",
-    "www/fcgiwrap",
-    "www/nginx",
-    "databases/mysql56-server"
+    "zoneminder",
+    "fcgiwrap",
+    "nginx",
+    "mysql56-server"
   ],
   "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
   "fingerprints": {


### PR DESCRIPTION
This PR aims to normalize how we install pkgs. Right now we use pkg origin's to install/identify packages. Now that is misleading at best, this PR changes that and we now use pkg names instead of origin to install/identify pkgs.