### PR TITLE
Correct name key in plugin manifests

### DIFF
--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -1,5 +1,5 @@
 {
-  "name": "jenkins",
+  "name": "jenkins-lts",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
   "pkgs": [

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -1,5 +1,5 @@
 {
-  "name": "Plex",
+  "name": "Plex-plexpass",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
   "pkgs": [


### PR DESCRIPTION
In 11.2 we use name key to identify a plugin, this disrupts iocage behavior if two plugin manifests contain the same value for their name key. When retrieval of a plugin json is desired, this gets greedy and matches the first plugin manifest which has the same key.