### PR TITLE
- Revert gitlab to 12.0.6

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -39,6 +39,14 @@
         "description": "Home media server to organize, play, and stream audio and video to a variety of devices.",
         "official": true
   },
+  "gitlab": {
+        "MANIFEST": "gitlab.json",
+        "name": "GitLab",
+        "primary_pkg": "gitlab-ce",
+        "icon": "https://www.trueos.org/iocage-icons/gitlab.png",
+        "description": "DevOps lifecycle tool that provides a Git repository manager providing wiki, issue-tracking, and CI/CD pipeline features.",
+        "official": true
+  },
   "gitlab-runner": {
         "MANIFEST": "gitlab-runner.json",
         "name": "GitLab Runner",

--- a/gitlab.json
+++ b/gitlab.json
@@ -5,15 +5,15 @@
   "artifact": "https://github.com/freenas/iocage-plugin-gitlab.git",
   "pkgs": [
     "gitlab-ce",
-    "postgresql11-server",
-    "postgresql11-contrib",
+    "postgresql95-server",
+    "postgresql95-contrib",
     "nginx",
     "gtar"
   ],
   "properties": {
      "allow_sysvipc": 1
   },
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+  "packagesite": "http://pkg.cdn.trueos.org/iocage/gitlab/11.2-Release",
   "fingerprints": {
 	  "iocage-plugins": [
 		  {


### PR DESCRIPTION
Before you approve this please approve first https://github.com/freenas/iocage-plugin-gitlab/pull/8

- Restore gitlab back to the index with the new location

Signed-off-by: Martin Wilke <miwi@ixsystems.com>