### PR TITLE
NAT support for 11.3

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -21,7 +21,8 @@
 	"allow_sysvipc": "1",
 	"sysvmsg": "new",
 	"sysvsem": "new",
-	"sysvshm": "new"
+	"sysvshm": "new",
+	"dhcp": 1
   },
   "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
   "fingerprints": {

--- a/backuppc.json
+++ b/backuppc.json
@@ -2,6 +2,10 @@
   "name": "BackupPC",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:9090)"
+  },
   "pkgs": [
     "backuppc4",
     "apache24"	  

--- a/bacula-server.json
+++ b/bacula-server.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-bacula-server.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(9102:9102)"
+  },
   "pkgs": [
     "bacula9-server",
     "postgresql95-server",

--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -2,6 +2,10 @@
   "name": "channels-dvr",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/fancybits/iocage-plugin-channels-dvr.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8089:8089)"
+  },
   "pkgs": [
     "ftp/curl",
     "security/ca_root_nss",

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(5050:5050)"
+  },
   "pkgs": [
     "couchpotato"
   ],

--- a/deluge.json
+++ b/deluge.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-deluge.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8112:8112)"
+  },
   "pkgs": [
     "deluge-cli"
   ],

--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -3,11 +3,14 @@
 	"plugin_schema": "2",
 	"release": "11.2-RELEASE",
 	"artifact": "https://github.com/timsavage/iocage-plugin-dnsmasq.git",
+	"properties": {
+            "dhcp": 1
+        },
 	"pkgs": [
 	   "dnsmasq",
 	   "python36"
 	],
-	"packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+	"packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
 	"fingerprints": {
 		"iocage-plugins": [
 			{

--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -4,8 +4,8 @@
 	"release": "11.2-RELEASE",
 	"artifact": "https://github.com/timsavage/iocage-plugin-dnsmasq.git",
 	"properties": {
-            "dhcp": 1
-        },
+	    "dhcp": 1
+	},
 	"pkgs": [
 	   "dnsmasq",
 	   "python36"

--- a/emby.json
+++ b/emby.json
@@ -2,6 +2,10 @@
   "name": "Emby",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8096:8096)"
+  },
   "pkgs": [
     "emby-server",
     "ffmpeg"

--- a/gitlab-runner.json
+++ b/gitlab-runner.json
@@ -2,6 +2,9 @@
   "name": "gitlab-runner",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbivens/iocage-plugin-gitlab-runner.git",
+  "properties": {
+     "dhcp": 1
+  },
   "pkgs": [
     "gitlab-runner"
   ],

--- a/homebridge.json
+++ b/homebridge.json
@@ -3,7 +3,7 @@
 	"release": "11.2-RELEASE",
 	"artifact": "https://github.com/grimneko/iocage-plugin-homebridge.git",
 	"properties": {
-		"vnet": "on"
+		"vnet": 1
 	},
 	"pkgs": [
 		"python",

--- a/homebridge.json
+++ b/homebridge.json
@@ -3,8 +3,7 @@
 	"release": "11.2-RELEASE",
 	"artifact": "https://github.com/grimneko/iocage-plugin-homebridge.git",
 	"properties": {
-		"vnet": "on",
-		"boot": "on"
+		"vnet": "on"
 	},
 	"pkgs": [
 		"python",

--- a/iconik.json
+++ b/iconik.json
@@ -3,7 +3,9 @@
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-iconik-storage-gateway.git",
   "properties": {
-    "vnet": 1
+    "vnet": 1,
+    "nat": 1,
+    "nat_forwards": "tcp(8000:8000)"
   },
   "pkgs": [
     "iconik_storage_gateway"

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -2,6 +2,10 @@
   "name": "jenkins-lts",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:8686)"
+  },
   "pkgs": [
     "jenkins-lts",
     "nginx"

--- a/jenkins.json
+++ b/jenkins.json
@@ -2,6 +2,10 @@
   "name": "jenkins",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:8585)"
+  },
   "pkgs": [
     "jenkins",
     "nginx"

--- a/madsonic.json
+++ b/madsonic.json
@@ -2,6 +2,10 @@
   "name": "MadSonic",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(4040:4040)"
+  },
   "pkgs": [
     "madsonic-standalone"
   ],

--- a/mineos.json
+++ b/mineos.json
@@ -6,7 +6,8 @@
     "mount_procfs":"1",
     "mount_linprocfs":"1",
     "allow_raw_sockets":"1",
-    "boot":"on"
+    "nat": 1,
+    "nat_forwards": "tcp(8443:8443)"
       },
   "pkgs": [
     "sysutils/rdiff-backup",

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:8282)"
+  },
   "pkgs": [
     "nextcloud-php71",
     "nginx",

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -2,6 +2,10 @@
   "name": "plexmediaserver-plexpass",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(32400:32401)"
+  },
   "pkgs": [
     "plexmediaserver-plexpass",
     "ffmpeg"

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -2,6 +2,10 @@
   "name": "Plex",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(32400:32400)"
+  },
   "pkgs": [
     "plexmediaserver",
     "ffmpeg"

--- a/quasselcore.json
+++ b/quasselcore.json
@@ -2,6 +2,10 @@
   "name": "Quasselcore",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-quassel.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(4242:4242)"
+  },
   "pkgs": [
     "quassel-core"
   ],

--- a/radarr.json
+++ b/radarr.json
@@ -2,6 +2,10 @@
   "name": "radarr",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(7878:7878)"
+  },
   "pkgs": [
     "radarr"
   ],

--- a/redmine.json
+++ b/redmine.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-redmine.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:3000)"
+  },
   "pkgs": [
     "redmine",
     "nginx",

--- a/rslsync.json
+++ b/rslsync.json
@@ -2,6 +2,10 @@
   "name": "rslsync",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-btsync.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8888:8888)"
+  },
   "pkgs": [
     "rslsync"
   ],

--- a/sickchill.json
+++ b/sickchill.json
@@ -2,6 +2,10 @@
   "name": "SickChill",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/dvarious/iocage-plugin-sickchill.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8081:8081)"
+  },
   "pkgs": [
     "lang/python27",
     "security/ca_root_nss",

--- a/sonarr.json
+++ b/sonarr.json
@@ -6,7 +6,9 @@
     "sonarr"
   ],
   "properties": {
-     "allow_sysvipc": "1"
+     "allow_sysvipc": 1,
+     "nat": 1,
+     "nat_forwards": "tcp(8989:8989)"
   },
   "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
   "fingerprints": {

--- a/subsonic.json
+++ b/subsonic.json
@@ -2,6 +2,10 @@
   "name": "SubSonic",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-subsonic.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(4040:4041)"
+  },
   "pkgs": [
     "subsonic-standalone"
   ],

--- a/syncthing.json
+++ b/syncthing.json
@@ -2,6 +2,10 @@
   "name": "syncthing",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:8384)"
+  },
   "pkgs": [
     "syncthing",
     "ca_root_nss",

--- a/tautulli.json
+++ b/tautulli.json
@@ -2,6 +2,10 @@
   "name": "Tautulli",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/arcooke/iocage-plugin-tautulli.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8181:8181)"
+  },
   "pkgs": [
     "lang/python27",
     "py27-sqlite3",

--- a/transmission.json
+++ b/transmission.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(9091:9091)"
+  },
   "pkgs": [
     "transmission-daemon",
     "transmission-web"	  

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -2,6 +2,10 @@
   "name": "unificontroller-lts",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8443:8445)"
+  },
   "pkgs": [
     "unifi-lts"
   ],

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -2,6 +2,10 @@
   "name": "unificontroller",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(8443:8444)"
+  },
   "pkgs": [
     "unifi5"
   ],

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -3,6 +3,10 @@
   "plugin_schema": "2",
   "release": "11.2-RELEASE",
   "artifact": "https://github.com/freenas/iocage-plugin-zoneminder.git",
+  "properties": {
+     "nat": 1,
+     "nat_forwards": "tcp(80:8383)"
+  },
   "pkgs": [
     "zoneminder",
     "fcgiwrap",


### PR DESCRIPTION
- Enable NAT support for 11.3
- Remove boot from properties as iocage adds them automatically
- While here move dnsmasq to 11.3-RELEASE packages
- Jira: NAS-102740 NAS-101215 NAS-101550

Signed-off-by: Martin Wilke <miwi@ixsystems.com>