### PR TITLE
NAS-102449 / 11.3 / Add Plugin Version/Revision

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -1,313 +1,313 @@
 {
-  "rslsync": {
+    "rslsync": {
         "MANIFEST": "rslsync.json",
         "name": "Resilio Sync",
         "primary_pkg": "rslsync",
         "icon": "https://www.trueos.org/iocage-icons/btsync.png",
         "description": "Fast and scalable file sync software for home and business.",
         "official": true
-  },
-  "backuppc": {
+    },
+    "backuppc": {
         "MANIFEST": "backuppc.json",
         "name": "BackupPC",
         "primary_pkg": "backuppc4",
         "icon": "https://www.trueos.org/iocage-icons/backuppc.png",
         "description": "Enterprise-grade system for backing up Linux, Windows, and MacOSX computers to a server.",
         "official": true
-  },
-  "clamav": {
+    },
+    "clamav": {
         "MANIFEST": "clamav.json",
         "name": "ClamAV",
         "primary_pkg": "clamav",
         "icon": "https://www.trueos.org/iocage-icons/clamav.png",
         "description": "Open source antivirus engine for detecting trojans, viruses, malware, and other malicious threats.",
         "official": true
-},
-  "couchpotato": {
+    },
+    "couchpotato": {
         "MANIFEST": "couchpotato.json",
         "name": "CouchPotato",
         "primary_pkg": "couchpotato",
         "icon": "https://www.trueos.org/iocage-icons/couchpotato.png",
         "description": "Automatic NZB and torrent downloader.",
         "official": true
-  },
-  "emby": {
+    },
+    "emby": {
         "MANIFEST": "emby.json",
         "name": "Emby",
         "primary_pkg": "emby-server",
         "icon": "https://www.trueos.org/iocage-icons/emby.png",
         "description": "Home media server to organize, play, and stream audio and video to a variety of devices.",
         "official": true
-  },
-  "gitlab": {
+    },
+    "gitlab": {
         "MANIFEST": "gitlab.json",
         "name": "GitLab",
         "primary_pkg": "gitlab-ce",
         "icon": "https://www.trueos.org/iocage-icons/gitlab.png",
         "description": "DevOps lifecycle tool that provides a Git repository manager providing wiki, issue-tracking, and CI/CD pipeline features.",
         "official": true
-  },
-  "gitlab-runner": {
+    },
+    "gitlab-runner": {
         "MANIFEST": "gitlab-runner.json",
         "name": "GitLab Runner",
         "primary_pkg": "gitlab-runner",
         "icon": "https://www.trueos.org/iocage-icons/gitlab.png",
         "description": "Run jobs and send results back to GitLab. Used in conjunction with GitLab CI.",
         "official": false
-  },
-  "jenkins": {
+    },
+    "jenkins": {
         "MANIFEST": "jenkins.json",
         "name": "Jenkins",
         "primary_pkg": "jenkins",
         "icon": "https://www.trueos.org/iocage-icons/jenkins.png",
         "description": "Open source build automation software.",
         "official": true
-  },
-  "jenkins-lts": {
+    },
+    "jenkins-lts": {
         "MANIFEST": "jenkins-lts.json",
         "name": "Jenkins (LTS)",
         "primary_pkg": "jenkins-lts",
         "icon": "https://www.trueos.org/iocage-icons/jenkins.png",
         "description": "Open source build automation software. (Long Term Support Version)",
         "official": true
-  },
-  "nextcloud": {
+    },
+    "nextcloud": {
         "MANIFEST": "nextcloud.json",
         "name": "Nextcloud",
         "primary_pkg": "nextcloud-php71",
         "icon": "https://www.trueos.org/iocage-icons/nextcloud.png",
         "description": "Suite of client-server software for creating and using file hosting services.",
         "official": true
-  },
-  "openvpn": {
+    },
+    "openvpn": {
         "MANIFEST": "openvpn.json",
         "name": "OpenVPN Server",
         "primary_pkg": "openvpn",
         "icon": "http://swupdate.openvpn.net/community/icons/ovpntech_key.png",
         "description": "Virtual private network software to create secure point-to-point connections.",
         "official": false
-  },
-  "plexmediaserver": {
+    },
+    "plexmediaserver": {
         "MANIFEST": "plexmediaserver.json",
         "name": "Plex Media Server",
         "primary_pkg": "plexmediaserver",
         "icon": "https://www.trueos.org/iocage-icons/plex.png",
         "description": "Media center software to easily manage and stream digital media.",
         "official": true
-  },
-  "redmine": {
+    },
+    "redmine": {
         "MANIFEST": "redmine.json",
         "name": "Redmine",
         "primary_pkg": "redmine",
         "icon": "https://www.trueos.org/iocage-icons/redmine.png",
         "description": "Open source ticket management software to track bugs and feature requests.",
         "official": true
-  },
-  "plexmediaserver-plexpass": {
+    },
+    "plexmediaserver-plexpass": {
         "MANIFEST": "plexmediaserver-plexpass.json",
         "name": "Plex Media Server (PlexPass)",
         "primary_pkg": "plexmediaserver-plexpass",
         "icon": "https://www.trueos.org/iocage-icons/plex.png",
         "description": "Media center software to easily manage and stream digital media. (Requires Subscription)",
         "official": true
-  },
-  "quasselcore": {
+    },
+    "quasselcore": {
         "MANIFEST": "quasselcore.json",
         "name": "Quasselcore",
         "primary_pkg": "quassel-core",
         "icon": "https://www.trueos.org/iocage-icons/quasselcore.png",
         "description": "Headless IRC Client that supports 24/7 connectivity. Quassel Client can be attached.",
         "official": true
-  },
-  "subsonic": {
+    },
+    "subsonic": {
         "MANIFEST": "subsonic.json",
         "name": "SubSonic",
         "primary_pkg": "subsonic-standalone",
         "icon": "https://www.trueos.org/iocage-icons/subsonic.png",
         "description": "Open source media streaming software and music player.",
         "official": true
-  },
-  "madsonic": {
+    },
+    "madsonic": {
         "MANIFEST": "madsonic.json",
         "name": "MadSonic",
         "primary_pkg": "madsonic-standalone",
         "icon": "https://www.trueos.org/iocage-icons/madsonic.png",
         "description": "Open source media streaming software and music player.",
         "official": true
-  },
-  "syncthing": {
+    },
+    "syncthing": {
         "MANIFEST": "syncthing.json",
         "name": "Syncthing",
         "primary_pkg": "syncthing",
         "icon": "https://www.trueos.org/iocage-icons/syncthing.png",
         "description": "Open source, peer-to-peer file synchronization application available for many operating systems.",
         "official": true
-  },
-  "deluge": {
+    },
+    "deluge": {
         "MANIFEST": "deluge.json",
         "name": "Deluge",
         "primary_pkg": "deluge-cli",
         "icon": "https://www.trueos.org/iocage-icons/deluge.png",
         "description": "Python-based Bittorent client.",
         "official": true
-  },
-  "sonarr": {
+    },
+    "sonarr": {
         "MANIFEST": "sonarr.json",
         "name": "Sonarr",
         "primary_pkg": "sonarr",
         "icon": "https://www.trueos.org/iocage-icons/sonarr.png",
         "description": "Multi-platform app to search, download, and manage TV shows.",
         "official": true
-  },
-  "transmission": {
+    },
+    "transmission": {
         "MANIFEST": "transmission.json",
         "name": "Transmission",
         "primary_pkg": "transmission-daemon",
         "icon": "https://www.trueos.org/iocage-icons/transmission.png",
         "description": "Fast and lightweight BitTorrent client.",
         "official": true
-  },
-  "sickchill": {
+    },
+    "sickchill": {
         "MANIFEST": "sickchill.json",
         "name": "SickChill",
         "primary_pkg": "Git branch - Master",
         "icon": "https://www.trueos.org/iocage-icons/sickchill.png",
         "description": "Automatic video library manager for TV Shows.",
         "official": false
-  },
-  "sickrage": {
+    },
+    "sickrage": {
         "MANIFEST": "sickrage.json",
         "name": "SickRage",
         "primary_pkg": "Git branch - Master",
         "icon": "https://www.trueos.org/iocage-icons/sickrage.png",
         "description": "Automatic video library manager for TV shows.",
         "official": true
-  },
-  "tarsnap": {
+    },
+    "tarsnap": {
         "MANIFEST": "tarsnap.json",
         "name": "Tarsnap",
         "primary_pkg": "tarsnap",
         "icon": "https://www.trueos.org/iocage-icons/tarsnap.png",
         "description": "Secure online backup service for UNIX-like operating systems.",
         "official": true
-  },
-  "tautulli": {
+    },
+    "tautulli": {
         "MANIFEST": "tautulli.json",
         "name": "Tautulli",
         "primary_pkg": "Git branch - Master",
         "icon": "https://www.trueos.org/iocage-icons/tautulli.png",
         "description": "Monitors analytics and notifications for Plex Media Server. (formerly known as PlexPy)",
         "official": false
-  },
-  "bru-server": {
+    },
+    "bru-server": {
         "MANIFEST": "bru-server.json",
         "name": "BRU Server",
         "icon": "https://www.trueos.org/iocage-icons/bru-server.png",
         "description": "BRU Server™ Backup and Recovery Software by TOLIS Group, Inc.",
         "license": "https://raw.githubusercontent.com/freenas/iocage-plugin-bru-server/master/bru-license",
         "official": true
-  },
-   "bacula-server": {
+    },
+    "bacula-server": {
         "MANIFEST": "bacula-server.json",
         "name": "Bacula-server",
         "primary_pkg": "bacula9-server",
         "icon": "https://www.trueos.org/iocage-icons/bacula-server.png",
         "description": "Manage, backup, recover, and verify data across a diverse network of computers.",
         "official": true
-  },
-   "xmrig": {
+    },
+    "xmrig": {
         "MANIFEST": "xmrig.json",
         "name": "XMRig",
         "primary_pkg": "xmrig",
         "icon": "https://www.trueos.org/iocage-icons/xmrig.png",
         "description": "High performance Monero (XMR) CPU miner written in C++.",
         "official": true
-  },
-  "qbittorrent": {
+    },
+    "qbittorrent": {
         "MANIFEST": "qbittorrent.json",
         "name": "qbittorrent",
         "primary_pkg": "qbittorrent-nox",
         "icon": "https://www.trueos.org/iocage-icons/qbittorrent.png",
         "description": "Open source Bittorent client written in C++ and QT.",
         "official": true
-  },
-  "weechat": {
+    },
+    "weechat": {
         "MANIFEST": "weechat.json",
         "name": "weechat",
         "primary_pkg": "weechat",
         "icon": "https://www.trueos.org/iocage-icons/weechat.png",
         "description": "Fast and light IRC client.",
         "official": true
-  },
- "irssi": {
+    },
+    "irssi": {
         "MANIFEST": "irssi.json",
         "name": "irssi",
         "primary_pkg": "irssi",
         "icon": "https://www.trueos.org/iocage-icons/irssi.png",
         "description": "Modular IRC client using a CLI interface.",
         "official": true
-  },
- "zoneminder": {
+    },
+    "zoneminder": {
         "MANIFEST": "zoneminder.json",
         "name": "Zoneminder",
         "primary_pkg": "zoneminder",
         "icon": "https://www.trueos.org/iocage-icons/zoneminder.png",
         "description": "Closed-circuit television management application which supports IP, USB, and analog cameras.",
         "official": true
-  },
- "radarr": {
+    },
+    "radarr": {
         "MANIFEST": "radarr.json",
         "name": "radarr",
         "primary_pkg": "radarr",
         "icon": "https://www.trueos.org/iocage-icons/radarr.png",
         "description": "Fork of Sonarr. Automatically download movies in the style of Couchpotato.",
         "official": true
-  },
- "mineos": {
+    },
+    "mineos": {
         "MANIFEST": "mineos.json",
         "name": "MineOS",
         "primary_pkg": "Git branch - Master",
         "icon": "https://www.trueos.org/iocage-icons/mineos.png",
         "description": "Set up and manage Minecraft servers.",
         "official": false
-  },
- "unificontroller": {
+    },
+    "unificontroller": {
         "MANIFEST": "unificontroller.json",
         "name": "unificontroller",
         "primary_pkg": "unifi5",
         "icon": "https://www.trueos.org/iocage-icons/unificontroller.png",
         "description": "Software-Defined Networking platform that provides an end-to-end system of network devices across different locations.",
         "official": false
-  },
- "unificontroller-lts": {
+    },
+    "unificontroller-lts": {
         "MANIFEST": "unificontroller-lts.json",
         "name": "unificontroller-lts",
         "primary_pkg": "unifi-lts",
         "icon": "https://www.trueos.org/iocage-icons/unificontroller.png",
         "description": "Software-Defined Networking platform that provides an end-to-end system of network devices across different locations. (Long term support version)",
         "official": false
-  },
- "homebridge": {
+    },
+    "homebridge": {
         "MANIFEST": "homebridge.json",
-        "name":	"Homebridge",
+        "name": "Homebridge",
         "icon": "https://camo.githubusercontent.com/97c6fb19fc469358ceada9d9abd96fa65fc14a0f/68747470733a2f2f636c2e6c792f3939653638616334396365662f4c6f676f32782e706e67",
         "description": "Lightweight iOS HomeKit API emulator. Enables adding unsupported devices to HomeKit.",
         "offical": false
- },
- "dnsmasq": {
+    },
+    "dnsmasq": {
         "MANIFEST": "dnsmasq.json",
         "name": "Dnsmasq",
         "icon": "https://www.trueos.org/iocage-icons/dnsmasq.png",
         "description": "Network infrastructure management for small networks: DNS, DHCP, router advertisement, and network boot.",
         "official": false,
         "primary_pkg": "dnsmasq"
- },
- "iconik": {
+    },
+    "iconik": {
         "MANIFEST": "iconik.json",
         "name": "Iconik",
         "description": "Streamlines media asset management by making local and cloud-based assets discoverable from a single interface.",
         "official": true,
         "icon": "https://raw.githubusercontent.com/freenas/iocage-ix-plugins/master/icons/iconik.png",
         "primary_pkg": "iconik_storage_gateway"
- }
+    }
 }

--- a/asigra-11.1.json
+++ b/asigra-11.1.json
@@ -1,40 +1,40 @@
 {
-  "name": "asigra",
-  "release": "11.1-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-asigra.git",
-  "pkgs": [
-	"ca_root_nss",
-	"gettext-runtime",
-	"icu",
-	"indexinfo",
-	"libxml2",
-	"nss_ldap",
-	"openldap-client",
-	"pam_ldap",
-	"lang/perl5.28",
-	"postgresql96-client",
-	"postgresql96-server",
-	"nginx"
-  ],
-  "properties": {
-	"mount_devfs": "1",
-	"mount_fdescfs": "1",
-	"mount_procfs": "1",
-	"allow_set_hostname": "1",
-	"allow_raw_sockets": "1",
-	"allow_sysvipc": "1",
-	"sysvmsg": "new",
-	"sysvsem": "new",
-	"sysvshm": "new"
-  },
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "asigra",
+    "release": "11.1-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-asigra.git",
+    "pkgs": [
+        "ca_root_nss",
+        "gettext-runtime",
+        "icu",
+        "indexinfo",
+        "libxml2",
+        "nss_ldap",
+        "openldap-client",
+        "pam_ldap",
+        "lang/perl5.28",
+        "postgresql96-client",
+        "postgresql96-server",
+        "nginx"
+    ],
+    "properties": {
+        "mount_devfs": "1",
+        "mount_fdescfs": "1",
+        "mount_procfs": "1",
+        "allow_set_hostname": "1",
+        "allow_raw_sockets": "1",
+        "allow_sysvipc": "1",
+        "sysvmsg": "new",
+        "sysvsem": "new",
+        "sysvshm": "new"
+    },
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/asigra-11.1.json
+++ b/asigra-11.1.json
@@ -36,5 +36,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/asigra.json
+++ b/asigra.json
@@ -1,40 +1,40 @@
 {
-  "name": "asigra",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/ix-plugin-hub/iocage-plugin-asigra.git",
-  "pkgs": [
-	"postgresql96-server",
-	"postgresql96-client",
-	"postgresql96-contrib",
-	"postgresql96-plpython",
-	"ca_root_nss",
-	"nss_ldap",
-	"pam_ldap",
-	"nginx",
-	"dsoperator",
-	"dssystem"
-  ],
-  "properties": {
-	"mount_devfs": 1,
-	"mount_fdescfs": 1,
-	"mount_procfs": 1,
-	"allow_set_hostname": 1,
-	"allow_raw_sockets": 1,
-	"allow_sysvipc": 1,
-	"sysvmsg": "new",
-	"sysvsem": "new",
-	"sysvshm": "new",
-	"vnet": 1,
-	"dhcp": 1
-  },
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "asigra",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/ix-plugin-hub/iocage-plugin-asigra.git",
+    "pkgs": [
+        "postgresql96-server",
+        "postgresql96-client",
+        "postgresql96-contrib",
+        "postgresql96-plpython",
+        "ca_root_nss",
+        "nss_ldap",
+        "pam_ldap",
+        "nginx",
+        "dsoperator",
+        "dssystem"
+    ],
+    "properties": {
+        "mount_devfs": 1,
+        "mount_fdescfs": 1,
+        "mount_procfs": 1,
+        "allow_set_hostname": 1,
+        "allow_raw_sockets": 1,
+        "allow_sysvipc": 1,
+        "sysvmsg": "new",
+        "sysvsem": "new",
+        "sysvshm": "new",
+        "vnet": 1,
+        "dhcp": 1
+    },
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/asigra.json
+++ b/asigra.json
@@ -36,5 +36,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/backuppc.json
+++ b/backuppc.json
@@ -1,23 +1,23 @@
 {
-  "name": "BackupPC",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:9090)"
-  },
-  "pkgs": [
-    "backuppc4",
-    "apache24"	  
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "BackupPC",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:9090)"
+    },
+    "pkgs": [
+        "backuppc4",
+        "apache24"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/backuppc.json
+++ b/backuppc.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/bacula-server.json
+++ b/bacula-server.json
@@ -21,5 +21,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/bacula-server.json
+++ b/bacula-server.json
@@ -1,25 +1,25 @@
 {
-  "name": "Bacula-server",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-bacula-server.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(9102:9102)"
-  },
-  "pkgs": [
-    "bacula9-server",
-    "postgresql95-server",
-    "postgresql95-contrib"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Bacula-server",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-bacula-server.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(9102:9102)"
+    },
+    "pkgs": [
+        "bacula9-server",
+        "postgresql95-server",
+        "postgresql95-contrib"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/bitcoin-node.json
+++ b/bitcoin-node.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/bitcoin-node.json
+++ b/bitcoin-node.json
@@ -1,22 +1,22 @@
 {
-  "name": "bitcoin-node",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-bitcoin-node.git",
-  "properties": {
-    "vnet": 1
-  },
-  "pkgs": [
-    "net-p2p/bitcoin-daemon"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "bitcoin-node",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-bitcoin-node.git",
+    "properties": {
+        "vnet": 1
+    },
+    "pkgs": [
+        "net-p2p/bitcoin-daemon"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/bru-server.json
+++ b/bru-server.json
@@ -13,5 +13,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/bru-server.json
+++ b/bru-server.json
@@ -1,18 +1,17 @@
 {
-  "name": "bru-server",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-bru-server.git",
-  "pkgs": [
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "bru-server",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-bru-server.git",
+    "pkgs": [],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -1,24 +1,24 @@
 {
-  "name": "channels-dvr",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/fancybits/iocage-plugin-channels-dvr.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8089:8089)"
-  },
-  "pkgs": [
-    "ftp/curl",
-    "security/ca_root_nss",
-    "security/sudo"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": false
+    "name": "channels-dvr",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/fancybits/iocage-plugin-channels-dvr.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8089:8089)"
+    },
+    "pkgs": [
+        "ftp/curl",
+        "security/ca_root_nss",
+        "security/sudo"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": false
 }

--- a/clamav.json
+++ b/clamav.json
@@ -1,18 +1,18 @@
 {
-  "name": "ClamAV",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
-  "pkgs": [
-    "clamav"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "ClamAV",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
+    "pkgs": [
+        "clamav"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/clamav.json
+++ b/clamav.json
@@ -14,5 +14,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -1,23 +1,23 @@
 {
-  "name": "CouchPotato",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(5050:5050)"
-  },
-  "pkgs": [
-    "couchpotato"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "CouchPotato",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(5050:5050)"
+    },
+    "pkgs": [
+        "couchpotato"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/crashplan.json
+++ b/crashplan.json
@@ -1,23 +1,23 @@
 {
-  "name": "Crashplan",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-crashplan.git",
-  "pkgs": [
-    "sysutils/linux-crashplan"
-  ],
-  "kmods": [
-    "linux64",
-    "linux"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Crashplan",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-crashplan.git",
+    "pkgs": [
+        "sysutils/linux-crashplan"
+    ],
+    "kmods": [
+        "linux64",
+        "linux"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/crashplan.json
+++ b/crashplan.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/deluge.json
+++ b/deluge.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/deluge.json
+++ b/deluge.json
@@ -1,23 +1,23 @@
 {
-  "name": "Deluge",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-deluge.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8112:8112)"
-  },
-  "pkgs": [
-    "deluge-cli"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Deluge",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-deluge.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8112:8112)"
+    },
+    "pkgs": [
+        "deluge-cli"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -1,23 +1,23 @@
 {
-	"name": "Dnsmasq",
-	"plugin_schema": "2",
-	"release": "11.2-RELEASE",
-	"artifact": "https://github.com/timsavage/iocage-plugin-dnsmasq.git",
-	"properties": {
-            "dhcp": 1
-        },
-	"pkgs": [
-	   "dnsmasq",
-	   "python36"
-	],
-	"packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-	"fingerprints": {
-		"iocage-plugins": [
-			{
-				"function": "sha256",
-				"fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-			}
-		]
-	},
-	"official": false
+    "name": "Dnsmasq",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/timsavage/iocage-plugin-dnsmasq.git",
+    "properties": {
+        "dhcp": 1
+    },
+    "pkgs": [
+        "dnsmasq",
+        "python36"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": false
 }

--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/emby.json
+++ b/emby.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/emby.json
+++ b/emby.json
@@ -1,23 +1,23 @@
 {
-  "name": "Emby",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8096:8096)"
-  },
-  "pkgs": [
-    "emby-server",
-    "ffmpeg"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Emby",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8096:8096)"
+    },
+    "pkgs": [
+        "emby-server",
+        "ffmpeg"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/gitlab-runner.json
+++ b/gitlab-runner.json
@@ -17,5 +17,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/gitlab-runner.json
+++ b/gitlab-runner.json
@@ -1,21 +1,21 @@
 {
-  "name": "gitlab-runner",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/lbivens/iocage-plugin-gitlab-runner.git",
-  "properties": {
-     "dhcp": 1
-  },
-  "pkgs": [
-    "gitlab-runner"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-          "iocage-plugins": [
-                  {
-                  "function": "sha256",
-                  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-          }
-          ]
-  },
-  "official": true
+    "name": "gitlab-runner",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/lbivens/iocage-plugin-gitlab-runner.git",
+    "properties": {
+        "dhcp": 1
+    },
+    "pkgs": [
+        "gitlab-runner"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/gitlab.json
+++ b/gitlab.json
@@ -1,26 +1,26 @@
 {
-  "name": "GitLab",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-gitlab.git",
-  "pkgs": [
-    "gitlab-ce",
-    "postgresql95-server",
-    "postgresql95-contrib",
-    "nginx",
-    "gtar"
-  ],
-  "properties": {
-     "allow_sysvipc": 1
-  },
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/gitlab/11.2-Release",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "GitLab",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-gitlab.git",
+    "pkgs": [
+        "gitlab-ce",
+        "postgresql95-server",
+        "postgresql95-contrib",
+        "nginx",
+        "gtar"
+    ],
+    "properties": {
+        "allow_sysvipc": 1
+    },
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/gitlab/11.2-Release",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/gitlab.json
+++ b/gitlab.json
@@ -22,5 +22,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/homebridge.json
+++ b/homebridge.json
@@ -1,27 +1,27 @@
 {
-	"name": "Homebridge",
-	"release": "11.2-RELEASE",
-	"artifact": "https://github.com/grimneko/iocage-plugin-homebridge.git",
-	"properties": {
-		"vnet": 1
-	},
-	"pkgs": [
-		"python",
-		"node",
-		"npm",
-		"dbus",
-		"avahi-libdns",
-		"gcc",
-		"nss_mdns"
-	],
-	"packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
-	"fingerprints": {
-		"plugin-default": [
-			{
-				"function": "sha256",
-				"fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
-			}
-		]
-	},
-	"offical": false
+    "name": "Homebridge",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/grimneko/iocage-plugin-homebridge.git",
+    "properties": {
+        "vnet": 1
+    },
+    "pkgs": [
+        "python",
+        "node",
+        "npm",
+        "dbus",
+        "avahi-libdns",
+        "gcc",
+        "nss_mdns"
+    ],
+    "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
+    "fingerprints": {
+        "plugin-default": [
+            {
+                "function": "sha256",
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+            }
+        ]
+    },
+    "offical": false
 }

--- a/homebridge.json
+++ b/homebridge.json
@@ -23,5 +23,6 @@
             }
         ]
     },
-    "offical": false
+    "offical": false,
+    "revision": "0"
 }

--- a/iconik.json
+++ b/iconik.json
@@ -1,23 +1,23 @@
 {
-  "name": "iconik-storage-gateway",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-iconik-storage-gateway.git",
-  "properties": {
-    "vnet": 1,
-    "nat": 1,
-    "nat_forwards": "tcp(8000:8000)"
-  },
-  "pkgs": [
-    "iconik_storage_gateway"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "iconik-storage-gateway",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-iconik-storage-gateway.git",
+    "properties": {
+        "vnet": 1,
+        "nat": 1,
+        "nat_forwards": "tcp(8000:8000)"
+    },
+    "pkgs": [
+        "iconik_storage_gateway"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/iconik.json
+++ b/iconik.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/irssi.json
+++ b/irssi.json
@@ -1,19 +1,19 @@
 {
-  "name": "irssi",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-irssi.git",
-  "pkgs": [
-    "irssi"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "irssi",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-irssi.git",
+    "pkgs": [
+        "irssi"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/irssi.json
+++ b/irssi.json
@@ -15,5 +15,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -1,23 +1,23 @@
 {
-  "name": "jenkins-lts",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:8686)"
-  },
-  "pkgs": [
-    "jenkins-lts",
-    "nginx"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "jenkins-lts",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:8686)"
+    },
+    "pkgs": [
+        "jenkins-lts",
+        "nginx"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/jenkins.json
+++ b/jenkins.json
@@ -1,23 +1,23 @@
 {
-  "name": "jenkins",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:8585)"
-  },
-  "pkgs": [
-    "jenkins",
-    "nginx"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "jenkins",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:8585)"
+    },
+    "pkgs": [
+        "jenkins",
+        "nginx"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/jenkins.json
+++ b/jenkins.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/madsonic.json
+++ b/madsonic.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/madsonic.json
+++ b/madsonic.json
@@ -1,22 +1,22 @@
 {
-  "name": "MadSonic",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(4040:4040)"
-  },
-  "pkgs": [
-    "madsonic-standalone"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "MadSonic",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(4040:4040)"
+    },
+    "pkgs": [
+        "madsonic-standalone"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/mineos.json
+++ b/mineos.json
@@ -31,5 +31,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/mineos.json
+++ b/mineos.json
@@ -1,35 +1,35 @@
 {
-  "name": "mineos",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
-  "properties": {
-    "mount_procfs": 1,
-    "mount_linprocfs": 1,
-    "allow_raw_sockets": 1,
-    "nat": 1,
-    "nat_forwards": "tcp(8443:8443)"
-  },
-  "pkgs": [
-    "sysutils/rdiff-backup",
-    "sysutils/screen",
-    "net/rsync",
-    "devel/gmake",
-    "devel/git-lite",
-    "lang/python2",
-    "www/node8",
-    "www/npm-node8",
-    "java/openjdk8-jre",
-    "ftp/wget",
-    "shells/bash"
-  ],
-  "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
-  "fingerprints": {
-	  "plugin-default": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
-	      }
-	    ]
+    "name": "mineos",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
+    "properties": {
+        "mount_procfs": 1,
+        "mount_linprocfs": 1,
+        "allow_raw_sockets": 1,
+        "nat": 1,
+        "nat_forwards": "tcp(8443:8443)"
+    },
+    "pkgs": [
+        "sysutils/rdiff-backup",
+        "sysutils/screen",
+        "net/rsync",
+        "devel/gmake",
+        "devel/git-lite",
+        "lang/python2",
+        "www/node8",
+        "www/npm-node8",
+        "java/openjdk8-jre",
+        "ftp/wget",
+        "shells/bash"
+    ],
+    "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
+    "fingerprints": {
+        "plugin-default": [
+            {
+                "function": "sha256",
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+            }
+        ]
     },
     "official": false
 }

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -21,5 +21,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,25 +1,25 @@
 {
-  "name": "Nextcloud",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:8282)"
-  },
-  "pkgs": [
-    "nextcloud-php71",
-    "nginx",
-    "mysql56-server"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Nextcloud",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:8282)"
+    },
+    "pkgs": [
+        "nextcloud-php71",
+        "nginx",
+        "mysql56-server"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/openvpn.json
+++ b/openvpn.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/openvpn.json
+++ b/openvpn.json
@@ -1,24 +1,24 @@
 {
-  "name": "OpenVPN",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/gitbulb/iocage-plugin-openvpn.git",
-  "pkgs": [
-    "openvpn"
-  ],
-  "properties": {
-    "allow_raw_sockets": 1,
-    "vnet": 1,
-    "allow_tun": 1
-  },
-  "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/latest",
-  "fingerprints": {
-    "plugin-default": [
-      {
-        "function": "sha256",
-        "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
-      }
-    ]
-  },
-  "official": false
+    "name": "OpenVPN",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/gitbulb/iocage-plugin-openvpn.git",
+    "pkgs": [
+        "openvpn"
+    ],
+    "properties": {
+        "allow_raw_sockets": 1,
+        "vnet": 1,
+        "allow_tun": 1
+    },
+    "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/latest",
+    "fingerprints": {
+        "plugin-default": [
+            {
+                "function": "sha256",
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+            }
+        ]
+    },
+    "official": false
 }

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -1,23 +1,23 @@
 {
-  "name": "plexmediaserver-plexpass",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(32400:32401)"
-  },
-  "pkgs": [
-    "plexmediaserver-plexpass",
-    "ffmpeg"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "plexmediaserver-plexpass",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(32400:32401)"
+    },
+    "pkgs": [
+        "plexmediaserver-plexpass",
+        "ffmpeg"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -1,23 +1,23 @@
 {
-  "name": "Plex",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(32400:32400)"
-  },
-  "pkgs": [
-    "plexmediaserver",
-    "ffmpeg"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Plex",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(32400:32400)"
+    },
+    "pkgs": [
+        "plexmediaserver",
+        "ffmpeg"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -1,22 +1,22 @@
 {
-  "name": "qbittorrent",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-qbittorrent.git",
-  "properties": {
-    "vnet": 1
-  },
-  "pkgs": [
-    "qbittorrent-nox"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "qbittorrent",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-qbittorrent.git",
+    "properties": {
+        "vnet": 1
+    },
+    "pkgs": [
+        "qbittorrent-nox"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/quasselcore.json
+++ b/quasselcore.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/quasselcore.json
+++ b/quasselcore.json
@@ -1,22 +1,22 @@
 {
-  "name": "Quasselcore",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-quassel.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(4242:4242)"
-  },
-  "pkgs": [
-    "quassel-core"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Quasselcore",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-quassel.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(4242:4242)"
+    },
+    "pkgs": [
+        "quassel-core"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/radarr.json
+++ b/radarr.json
@@ -1,22 +1,22 @@
 {
-  "name": "radarr",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(7878:7878)"
-  },
-  "pkgs": [
-    "radarr"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "radarr",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(7878:7878)"
+    },
+    "pkgs": [
+        "radarr"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/radarr.json
+++ b/radarr.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/redmine.json
+++ b/redmine.json
@@ -21,5 +21,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/redmine.json
+++ b/redmine.json
@@ -1,25 +1,25 @@
 {
-  "name": "Redmine",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-redmine.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:3000)"
-  },
-  "pkgs": [
-    "redmine",
-    "nginx",
-    "mysql56-server"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Redmine",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-redmine.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:3000)"
+    },
+    "pkgs": [
+        "redmine",
+        "nginx",
+        "mysql56-server"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/rslsync.json
+++ b/rslsync.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/rslsync.json
+++ b/rslsync.json
@@ -1,22 +1,22 @@
 {
-  "name": "rslsync",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-btsync.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8888:8888)"
-  },
-  "pkgs": [
-    "rslsync"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "rslsync",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-btsync.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8888:8888)"
+    },
+    "pkgs": [
+        "rslsync"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/sabnzbd.json
+++ b/sabnzbd.json
@@ -1,18 +1,18 @@
 {
-  "name": "SABnzbd",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-sabnzbd",
-  "pkgs": [
-    "sabnzbdplus"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "SABnzbd",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-sabnzbd",
+    "pkgs": [
+        "sabnzbdplus"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/sabnzbd.json
+++ b/sabnzbd.json
@@ -14,5 +14,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/sickchill.json
+++ b/sickchill.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/sickchill.json
+++ b/sickchill.json
@@ -1,24 +1,24 @@
 {
-  "name": "SickChill",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/dvarious/iocage-plugin-sickchill.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8081:8081)"
-  },
-  "pkgs": [
-    "lang/python27",
-    "security/ca_root_nss",
-    "databases/py-sqlite3"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": false
+    "name": "SickChill",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/dvarious/iocage-plugin-sickchill.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8081:8081)"
+    },
+    "pkgs": [
+        "lang/python27",
+        "security/ca_root_nss",
+        "databases/py-sqlite3"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": false
 }

--- a/sickrage.json
+++ b/sickrage.json
@@ -17,5 +17,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/sickrage.json
+++ b/sickrage.json
@@ -1,21 +1,21 @@
 {
-  "name": "SickRage",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-sickrage.git",
-  "pkgs": [
-    "lang/python27",
-    "security/ca_root_nss",
-    "databases/py-sqlite3"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "SickRage",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-sickrage.git",
+    "pkgs": [
+        "lang/python27",
+        "security/ca_root_nss",
+        "databases/py-sqlite3"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/sonarr.json
+++ b/sonarr.json
@@ -1,23 +1,23 @@
 {
-  "name": "Sonarr",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-sonarr.git",
-  "pkgs": [
-    "sonarr"
-  ],
-  "properties": {
-     "allow_sysvipc": 1,
-     "nat": 1,
-     "nat_forwards": "tcp(8989:8989)"
-  },
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Sonarr",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-sonarr.git",
+    "pkgs": [
+        "sonarr"
+    ],
+    "properties": {
+        "allow_sysvipc": 1,
+        "nat": 1,
+        "nat_forwards": "tcp(8989:8989)"
+    },
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/sonarr.json
+++ b/sonarr.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/subsonic.json
+++ b/subsonic.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/subsonic.json
+++ b/subsonic.json
@@ -1,22 +1,22 @@
 {
-  "name": "SubSonic",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-subsonic.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(4040:4041)"
-  },
-  "pkgs": [
-    "subsonic-standalone"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "SubSonic",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-subsonic.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(4040:4041)"
+    },
+    "pkgs": [
+        "subsonic-standalone"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/syncthing.json
+++ b/syncthing.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/syncthing.json
+++ b/syncthing.json
@@ -1,24 +1,24 @@
 {
-  "name": "syncthing",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:8384)"
-  },
-  "pkgs": [
-    "syncthing",
-    "ca_root_nss",
-    "nginx"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "syncthing",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:8384)"
+    },
+    "pkgs": [
+        "syncthing",
+        "ca_root_nss",
+        "nginx"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -1,19 +1,19 @@
 {
-  "name": "Tarsnap",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
-  "pkgs": [
-    "tarsnap"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Tarsnap",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
+    "pkgs": [
+        "tarsnap"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -15,5 +15,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/tautulli.json
+++ b/tautulli.json
@@ -22,5 +22,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/tautulli.json
+++ b/tautulli.json
@@ -1,27 +1,26 @@
 {
-  "name": "Tautulli",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/arcooke/iocage-plugin-tautulli.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8181:8181)"
-  },
-  "pkgs": [
-    "lang/python27",
-    "py27-sqlite3",
-    "py27-openssl",
-    "security/ca_root_nss",
-    "git"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": false
+    "name": "Tautulli",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/arcooke/iocage-plugin-tautulli.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8181:8181)"
+    },
+    "pkgs": [
+        "lang/python27",
+        "py27-sqlite3",
+        "py27-openssl",
+        "security/ca_root_nss",
+        "git"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": false
 }
- 

--- a/transmission.json
+++ b/transmission.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/transmission.json
+++ b/transmission.json
@@ -1,24 +1,24 @@
 {
-  "name": "Transmission",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(9091:9091)"
-  },
-  "pkgs": [
-    "transmission-daemon",
-    "transmission-web"	  
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Transmission",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(9091:9091)"
+    },
+    "pkgs": [
+        "transmission-daemon",
+        "transmission-web"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/ttrss.json
+++ b/ttrss.json
@@ -1,18 +1,18 @@
 {
-  "name": "TinyTinyRSS",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-ttrss",
-  "pkgs": [
-    "tt-rss"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "TinyTinyRSS",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-ttrss",
+    "pkgs": [
+        "tt-rss"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/ttrss.json
+++ b/ttrss.json
@@ -14,5 +14,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -1,22 +1,22 @@
 {
-  "name": "unificontroller-lts",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8443:8445)"
-  },
-  "pkgs": [
-    "unifi-lts"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": false
+    "name": "unificontroller-lts",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8443:8445)"
+    },
+    "pkgs": [
+        "unifi-lts"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": false
 }

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -1,22 +1,22 @@
 {
-  "name": "unificontroller",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(8443:8444)"
-  },
-  "pkgs": [
-    "unifi5"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "unificontroller",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(8443:8444)"
+    },
+    "pkgs": [
+        "unifi5"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/weechat.json
+++ b/weechat.json
@@ -1,19 +1,19 @@
 {
-  "name": "weechat",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-weechat.git",
-  "pkgs": [
-    "weechat"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "weechat",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-weechat.git",
+    "pkgs": [
+        "weechat"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/weechat.json
+++ b/weechat.json
@@ -15,5 +15,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/xmrig.json
+++ b/xmrig.json
@@ -1,19 +1,19 @@
 {
-  "name": "xmrig",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-xmrig.git",
-  "pkgs": [
-    "xmrig"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "xmrig",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-xmrig.git",
+    "pkgs": [
+        "xmrig"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/xmrig.json
+++ b/xmrig.json
@@ -15,5 +15,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -1,26 +1,26 @@
 {
-  "name": "Zoneminder",
-  "plugin_schema": "2",
-  "release": "11.2-RELEASE",
-  "artifact": "https://github.com/freenas/iocage-plugin-zoneminder.git",
-  "properties": {
-     "nat": 1,
-     "nat_forwards": "tcp(80:8383)"
-  },
-  "pkgs": [
-    "zoneminder",
-    "fcgiwrap",
-    "nginx",
-    "mysql56-server"
-  ],
-  "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
-  "fingerprints": {
-	  "iocage-plugins": [
-		  {
-		  "function": "sha256",
-		  "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-	  }
-	  ]
-  },
-  "official": true
+    "name": "Zoneminder",
+    "plugin_schema": "2",
+    "release": "11.2-RELEASE",
+    "artifact": "https://github.com/freenas/iocage-plugin-zoneminder.git",
+    "properties": {
+        "nat": 1,
+        "nat_forwards": "tcp(80:8383)"
+    },
+    "pkgs": [
+        "zoneminder",
+        "fcgiwrap",
+        "nginx",
+        "mysql56-server"
+    ],
+    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+            }
+        ]
+    },
+    "official": true
 }

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -22,5 +22,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }


### PR DESCRIPTION
This PR formats all the plugin manifests to correctly write out the json indenting to 4 spaces (this helps immensely if we want to add/change similar keys programmatically ). It also adds plugin version/revision keys so we can keep track of a plugin's version and to notify the user if we should update or not.