### PR TITLE
Add chromium dependency to channels-dvr

### DIFF
--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -9,7 +9,8 @@
     "pkgs": [
         "ftp/curl",
         "security/ca_root_nss",
-        "security/sudo"
+        "security/sudo",
+        "www/chromium"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
     "fingerprints": {


### PR DESCRIPTION
Required by new versions of the dvr for some features

Previously we told users who wanted to use these features to connect to the jail and install it themselves, but this seems to no longer work for them as the main fbsd repo is not available by default?