### PR TITLE
add channels-dvr plugin to the INDEX

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -317,5 +317,13 @@
         "official": true,
         "icon": "https://raw.githubusercontent.com/freenas/iocage-ix-plugins/master/icons/iconik.png",
         "primary_pkg": "iconik_storage_gateway"
+    },
+    "channels-dvr": {
+        "MANIFEST": "channels-dvr.json",
+        "name": "Channels DVR",
+        "icon": "https://getchannels.com/assets/img/icon-1024.png",
+        "description": "DVR server for the Channels apps. Makes digital recordings of broadcast television using HDHomeRun network tuners. (Requires Subscription)",
+        "primary_pkg": "",
+        "official": false
     }
 }


### PR DESCRIPTION
We have a growing number of Channels DVR subscribers who are using FreeNAS as their server of choice. We'd like for them to be able to easily click and install our DVR server on their systems.