### PR TITLE
NAS-103416 / 11.3 / - Move all Plugins to FreeBSD 11.3 jails

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -1,6 +1,6 @@
 {
     "name": "asigra",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/ix-plugin-hub/iocage-plugin-asigra.git",
     "pkgs": [
         "postgresql96-server",

--- a/backuppc.json
+++ b/backuppc.json
@@ -1,6 +1,6 @@
 {
     "name": "BackupPC",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
     "properties": {
         "nat": 1,

--- a/bacula-server.json
+++ b/bacula-server.json
@@ -1,7 +1,7 @@
 {
     "name": "Bacula-server",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bacula-server.git",
     "properties": {
         "nat": 1,

--- a/bitcoin-node.json
+++ b/bitcoin-node.json
@@ -1,7 +1,7 @@
 {
     "name": "bitcoin-node",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bitcoin-node.git",
     "properties": {
         "vnet": 1

--- a/bru-server.json
+++ b/bru-server.json
@@ -1,7 +1,7 @@
 {
     "name": "bru-server",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bru-server.git",
     "pkgs": [],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",

--- a/clamav.json
+++ b/clamav.json
@@ -1,6 +1,6 @@
 {
     "name": "ClamAV",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
     "pkgs": [
         "clamav"

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -1,7 +1,7 @@
 {
     "name": "CouchPotato",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
     "properties": {
         "nat": 1,

--- a/deluge.json
+++ b/deluge.json
@@ -1,7 +1,7 @@
 {
     "name": "Deluge",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-deluge.git",
     "properties": {
         "nat": 1,

--- a/emby.json
+++ b/emby.json
@@ -1,6 +1,6 @@
 {
     "name": "Emby",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
     "properties": {
         "nat": 1,

--- a/gitlab-runner.json
+++ b/gitlab-runner.json
@@ -1,6 +1,6 @@
 {
     "name": "gitlab-runner",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/lbivens/iocage-plugin-gitlab-runner.git",
     "properties": {
         "dhcp": 1

--- a/gitlab.json
+++ b/gitlab.json
@@ -1,7 +1,7 @@
 {
     "name": "GitLab",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-gitlab.git",
     "pkgs": [
         "gitlab-ce",

--- a/iconik.json
+++ b/iconik.json
@@ -1,6 +1,6 @@
 {
     "name": "iconik-storage-gateway",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-iconik-storage-gateway.git",
     "properties": {
         "vnet": 1,

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -1,6 +1,6 @@
 {
     "name": "jenkins-lts",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
     "properties": {
         "nat": 1,

--- a/jenkins.json
+++ b/jenkins.json
@@ -1,6 +1,6 @@
 {
     "name": "jenkins",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
     "properties": {
         "nat": 1,

--- a/mineos.json
+++ b/mineos.json
@@ -1,6 +1,6 @@
 {
     "name": "mineos",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
     "properties": {
         "mount_procfs": 1,

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,7 +1,7 @@
 {
     "name": "Nextcloud",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
     "properties": {
         "nat": 1,

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -1,6 +1,6 @@
 {
     "name": "plexmediaserver-plexpass",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
     "properties": {
         "nat": 1,

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -1,6 +1,6 @@
 {
     "name": "Plex",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
     "properties": {
         "nat": 1,

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -1,7 +1,7 @@
 {
     "name": "qbittorrent",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-qbittorrent.git",
     "properties": {
         "vnet": 1

--- a/radarr.json
+++ b/radarr.json
@@ -1,6 +1,6 @@
 {
     "name": "radarr",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
     "properties": {
         "nat": 1,

--- a/redmine.json
+++ b/redmine.json
@@ -1,7 +1,7 @@
 {
     "name": "Redmine",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-redmine.git",
     "properties": {
         "nat": 1,

--- a/rslsync.json
+++ b/rslsync.json
@@ -1,6 +1,6 @@
 {
     "name": "rslsync",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-btsync.git",
     "properties": {
         "nat": 1,

--- a/sonarr.json
+++ b/sonarr.json
@@ -1,6 +1,6 @@
 {
     "name": "Sonarr",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-sonarr.git",
     "pkgs": [
         "sonarr"

--- a/subsonic.json
+++ b/subsonic.json
@@ -1,6 +1,6 @@
 {
     "name": "SubSonic",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-subsonic.git",
     "properties": {
         "nat": 1,

--- a/syncthing.json
+++ b/syncthing.json
@@ -1,6 +1,6 @@
 {
     "name": "syncthing",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
     "properties": {
         "nat": 1,

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -1,7 +1,7 @@
 {
     "name": "Tarsnap",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
     "pkgs": [
         "tarsnap"

--- a/tautulli.json
+++ b/tautulli.json
@@ -1,6 +1,6 @@
 {
     "name": "Tautulli",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/arcooke/iocage-plugin-tautulli.git",
     "properties": {
         "nat": 1,

--- a/transmission.json
+++ b/transmission.json
@@ -1,7 +1,7 @@
 {
     "name": "Transmission",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
     "properties": {
         "nat": 1,

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -1,7 +1,7 @@
 {
     "name": "Zoneminder",
     "plugin_schema": "2",
-    "release": "11.2-RELEASE",
+    "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-zoneminder.git",
     "properties": {
         "nat": 1,


### PR DESCRIPTION
As FreeNAS 11.3 is around the corner move all plugins to FreeBSD 11.3 as well.