### PR TITLE
NAS-103489 / 11.3 / NAT Support / Vnet cleanup (by miwi-fbsd)

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -24,7 +24,6 @@
         "sysvmsg": "new",
         "sysvsem": "new",
         "sysvshm": "new",
-        "vnet": 1,
         "dhcp": 1
     },
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",

--- a/bitcoin-node.json
+++ b/bitcoin-node.json
@@ -4,7 +4,7 @@
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bitcoin-node.git",
     "properties": {
-        "vnet": 1
+        "nat": 1
     },
     "pkgs": [
         "net-p2p/bitcoin-daemon"

--- a/bru-server.json
+++ b/bru-server.json
@@ -3,6 +3,9 @@
     "plugin_schema": "2",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bru-server.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
     "fingerprints": {

--- a/clamav.json
+++ b/clamav.json
@@ -2,6 +2,9 @@
     "name": "ClamAV",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [
         "clamav"
     ],

--- a/gitlab.json
+++ b/gitlab.json
@@ -11,7 +11,8 @@
         "gtar"
     ],
     "properties": {
-        "allow_sysvipc": 1
+        "allow_sysvipc": 1,
+        "dhcp": 1
     },
     "packagesite": "http://pkg.cdn.trueos.org/iocage/gitlab/11.3-Release",
     "fingerprints": {

--- a/iconik.json
+++ b/iconik.json
@@ -3,7 +3,6 @@
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-iconik-storage-gateway.git",
     "properties": {
-        "vnet": 1,
         "nat": 1,
         "nat_forwards": "tcp(8000:8000)"
     },

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -4,7 +4,7 @@
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-qbittorrent.git",
     "properties": {
-        "vnet": 1
+        "dhcp": 1
     },
     "pkgs": [
         "qbittorrent-nox"

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -3,6 +3,9 @@
     "plugin_schema": "2",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [
         "tarsnap"
     ],


### PR DESCRIPTION
- Set DHCP for qbittorent (to many header redirects, http protocal issue from the software itself.)
- Set DHCP for gitlab need direct access for git protocol
- Remove vnet support its automated now
- Added nat support for the last plugins