### PR TITLE
Fix 'Using Local File' example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ it will appear in iocage's plugin listing
 
 ## Using Local File
 ```
-iocage fetch -P --name /the/path/to/jenkins.json ip4_addr="re0|192.168.0.100"
+iocage fetch -P /the/path/to/jenkins.json ip4_addr="re0|192.168.0.100" -n jenkins
 ```
 
 ## Pulling from Internet


### PR DESCRIPTION
When developing local plugins the `-P` and `--name` option can not be used together as described in the README.md.
I'd like to suggest to prepend the name option with the `-n`.

```
~/workspace/iocage-plugins #iocage --version
Version 1.2
~/worspace/iocage-plugins # iocage fetch -P --name ./jenkins.json ip4_addr="re0|192.168.0.100"
/zroot/iocage/.plugins/github_com_freenas_iocage-ix-plugins_git/--name.json
was not found!
```