### PR TITLE
NAS-104264 / 11.3 / set explicit lang/python3 (by miwi-fbsd)

### DIFF
--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -7,7 +7,8 @@
         "dhcp": 1
     },
     "pkgs": [
-        "qbittorrent-nox"
+        "qbittorrent-nox",
+        "lang/python3"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
     "fingerprints": {


### PR DESCRIPTION
This will fix https://github.com/freenas/iocage-ports/issues/40