### PR TITLE
Update to mysql57 (default) for zoneminder

### DIFF
--- a/zoneminder.json
+++ b/zoneminder.json
@@ -11,7 +11,7 @@
         "zoneminder",
         "fcgiwrap",
         "nginx",
-        "mysql56-server"
+        "mysql57-server"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Update zoneminder to use mysql57 (new default version)