### PR TITLE
NAS-105632 / 12.0 / Switch mineos to node10 and python3

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -16,9 +16,9 @@
         "net/rsync",
         "devel/gmake",
         "devel/git-lite",
-        "lang/python2",
-        "www/node8",
-        "www/npm-node8",
+        "lang/python3",
+        "www/node10",
+        "www/npm-node10",
         "java/openjdk8-jre",
         "ftp/wget",
         "shells/bash"


### PR DESCRIPTION
Packages node8 and npm-node8 have been marked as deprecated.  As a result, the MineOS plugin no longer builds properly.  

Reference JIRA ticket **NAS-105632**

Please port to 11.3

Thank you!