### PR TITLE
Add zrepl plugin

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -230,5 +230,15 @@
         "category": "collaboration",
         "maintainer": "iXsystems <dev@ixsystems.com>",
         "homepage": "https://iconik.io/"
+    },
+    "zrepl": {
+        "MANIFEST": "zrepl.json",
+        "name": "zrepl",
+        "description": "zrepl is a one-stop, integrated solution for ZFS replication.",
+        "official": false,
+        "primary_pkg": "zrepl",
+        "category": "sysutils",
+        "maintainer": "John Ramsden <johnramsden@riseup.net>",
+        "homepage": "https://zrepl.github.io/"
     }
 }

--- a/zrepl.json
+++ b/zrepl.json
@@ -1,0 +1,25 @@
+{
+    "name": "zrepl",
+    "plugin_schema": 2,
+    "release": "11.3-RELEASE",
+    "artifact": "https://github.com/johnramsden/iocage-plugin-zrepl.git",
+    "official": false,
+    "properties": {
+        "nat": 1,
+        "jail_zfs": "on",
+        "jail_zfs_mountpoint": "none"
+    },
+    "pkgs": [
+        "zrepl"
+    ],
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+    "fingerprints": {
+        "iocage-plugins": [
+            {
+                "function": "sha256",
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+            }
+        ]
+    },
+    "revision": "0"
+}


### PR DESCRIPTION
## Summary

[zrepl](https://zrepl.github.io/) is zfs replication software.

## Tests

Tested the plug-in via:

```
iocage fetch -P /tmp/zrepl.json --name zrepl-test jail_zfs_dataset="zrepl"
```

## Questions

I wasn't sure who should be labelled as the maintainer, myself or ixsystems. It also does not have a icon, so I left it out.

Regarding setup tasks. I couldn't find a way to run commands on the main system, I don't know if this is possible. Is there a way to have a user specify a dataset they want delegated, and optionally created? For now I have left a [message](https://github.com/johnramsden/iocage-plugin-zrepl/blob/9aa1899a42797e3070a6e3f63ab3b3c99db73dfc/post_install.sh#L12-L29) in the `post_install.sh` stating:

> A ZFS dataset must be delegated into the zrepl jail. Create a dataset on the
> host if one was not delegated during jail creation, stop the plugin jail,
> and set the following iocage property:
> 
>     jail_zfs_dataset=<delegated dataset>
> 
> The "\<delegated dataset\>" should not contain the pool name.
> 
> 