### PR TITLE
nextcloud: Add imagick PHP module dependency.

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -10,6 +10,7 @@
     },
     "pkgs": [
         "nextcloud-php74",
+        "php74-pecl-imagick-im7",
         "nginx",
         "mysql57-server"
     ],


### PR DESCRIPTION
Nextcloud 18 can leverage the "imagick" PHP module to improve
photo/image performance.  Add a dependency on the php74-pecl-imagick-im7
package to make that module available to Nextcloud, accordingly.  Doing
so also addresses a warning displayed in the Nextcloud Web UI
Settings->Overview (i.e., /settings/admin/overview) page about the
missing "imagick" module.