### PR TITLE
gitlab plugin working with FreeNAS 11.3

### DIFF
--- a/gitlab.json
+++ b/gitlab.json
@@ -1,0 +1,27 @@
+{
+  "name": "GitLab",
+  "release": "11.3-RELEASE",
+  "artifact": "https://github.com/pandorixtech/iocage-plugin-gitlab.git",
+  "pkgs": [
+    "www/gitlab-ce",
+    "postgresql11-server",
+    "postgresql11-contrib",
+    "postgresql11-client",
+    "nginx",
+    "gtar"
+  ],
+  "properties": {
+     "dhcp": "on",
+     "allow_sysvipc": "1"
+  },
+  "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+  "fingerprints": {
+	  "iocage-plugins": [
+		  {
+		  "function": "sha256",
+                  "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+	  }
+	  ]
+  },
+  "official": true
+}


### PR DESCRIPTION
This will allow to install gitlab as a plugin using dhcp.
the iocage-plugin-gitlab.git needed some fixes to install successfully the new gitlab-ce package, that's the reason why the artifact is directed to my forked version.

If it's preferred to keep using the freenas repository, please let me know and I'll update the pull request. 