### PR TITLE
Update to using 12.1-RELEASE as the base for new plugins on 12.0 and

### DIFF
--- a/backuppc.json
+++ b/backuppc.json
@@ -1,6 +1,6 @@
 {
     "name": "BackupPC",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "official": false,
     "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
     "properties": {

--- a/bitcoin-node.json
+++ b/bitcoin-node.json
@@ -1,7 +1,7 @@
 {
     "name": "bitcoin-node",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-bitcoin-node.git",
     "official": false,
     "properties": {

--- a/bru-server.json
+++ b/bru-server.json
@@ -1,7 +1,7 @@
 {
     "name": "bru-server",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "official": false,
     "artifact": "https://github.com/freenas/iocage-plugin-bru-server.git",
     "properties": {

--- a/clamav.json
+++ b/clamav.json
@@ -1,6 +1,6 @@
 {
     "name": "ClamAV",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-clamav.git",
     "official": false,
     "properties": {

--- a/couchpotato.json
+++ b/couchpotato.json
@@ -1,7 +1,7 @@
 {
     "name": "CouchPotato",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-couchpotato.git",
     "official": false,
     "properties": {

--- a/emby.json
+++ b/emby.json
@@ -1,6 +1,6 @@
 {
     "name": "Emby",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
     "official": false,
     "properties": {

--- a/jenkins-lts.json
+++ b/jenkins-lts.json
@@ -1,6 +1,6 @@
 {
     "name": "jenkins-lts",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-jenkins-lts.git",
     "official": false,
     "properties": {

--- a/jenkins.json
+++ b/jenkins.json
@@ -1,6 +1,6 @@
 {
     "name": "jenkins",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-jenkins.git",
     "official": false,
     "properties": {

--- a/mineos.json
+++ b/mineos.json
@@ -1,6 +1,6 @@
 {
     "name": "mineos",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
     "official": false,
     "properties": {

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,7 +1,7 @@
 {
     "name": "Nextcloud",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
     "official": false,
     "properties": {

--- a/plexmediaserver-plexpass.json
+++ b/plexmediaserver-plexpass.json
@@ -1,6 +1,6 @@
 {
     "name": "plexmediaserver-plexpass",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "official": false,
     "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git",
     "properties": {

--- a/plexmediaserver.json
+++ b/plexmediaserver.json
@@ -1,6 +1,6 @@
 {
     "name": "Plex",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-plexmediaserver.git",
     "official": "false",
     "properties": {

--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -1,7 +1,7 @@
 {
     "name": "qbittorrent",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-qbittorrent.git",
     "official": false,
     "properties": {

--- a/radarr.json
+++ b/radarr.json
@@ -1,6 +1,6 @@
 {
     "name": "radarr",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
     "official": false,
     "properties": {

--- a/sonarr.json
+++ b/sonarr.json
@@ -1,6 +1,6 @@
 {
     "name": "Sonarr",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-sonarr.git",
     "official": false,
     "pkgs": [

--- a/syncthing.json
+++ b/syncthing.json
@@ -1,6 +1,6 @@
 {
     "name": "syncthing",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
     "official": false,
     "properties": {

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -1,7 +1,7 @@
 {
     "name": "Tarsnap",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
     "official": false,
     "properties": {

--- a/tautulli.json
+++ b/tautulli.json
@@ -1,6 +1,6 @@
 {
     "name": "Tautulli",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/arcooke/iocage-plugin-tautulli.git",
     "official": false,
     "properties": {

--- a/transmission.json
+++ b/transmission.json
@@ -1,7 +1,7 @@
 {
     "name": "Transmission",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-transmission.git",
     "official": false,
     "properties": {

--- a/zoneminder.json
+++ b/zoneminder.json
@@ -1,7 +1,7 @@
 {
     "name": "Zoneminder",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-zoneminder.git",
     "official": false,
     "properties": {


### PR DESCRIPTION
later

This gets the master / 12.0-RELEASE branches in sync, so that plugins start using FreeBSD 12.1-RELEASE as the base jail for upcoming 12.0-BETA1 and beyond.

