### PR TITLE
NAS-106468 / 12.1 / Add ca_root_nss package to bru-server plugin

### DIFF
--- a/bru-server.json
+++ b/bru-server.json
@@ -7,7 +7,7 @@
     "properties": {
         "nat": 1
     },
-    "pkgs": [],
+    "pkgs": ["ca_root_nss"],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {
         "iocage-plugins": [


### PR DESCRIPTION
Trusted CA certs are not shipped in base OS and have to be pulled in separately by ca_root_nss package. If we don't do that, openssl rejects certs the plugin tries to use.