### PR TITLE
nextcloud: Add bcmath and gmp PHP module deps

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -11,6 +11,8 @@
     "pkgs": [
         "nextcloud-php74",
         "php74-pecl-imagick-im7",
+        "php74-bcmath",
+        "php74-gmp",
         "nginx",
         "mysql57-server"
     ],


### PR DESCRIPTION
Nextcloud 19 warns about two new missing recommended PHP modules,
bcmath and gmp, that could improve performance and compatibility.  Add
dependencies on the php74-bcmath and php74-gmp packages, accordingly.