### PR TITLE
NAS-106965 / None / Use quarterly packagesite for qbittorrent

### DIFF
--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -11,7 +11,7 @@
         "qbittorrent-nox",
         "lang/python3"
     ],
-    "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
qbittorrent-nox is not present in 11 latest freebsd packages and is available in quarterly packages. So this PR aims to use quarterly for qbittorrent.