### PR TITLE
Move from python2 to python3

### DIFF
--- a/tautulli.json
+++ b/tautulli.json
@@ -8,9 +8,9 @@
         "nat_forwards": "tcp(8181:8181)"
     },
     "pkgs": [
-        "lang/python27",
-        "py27-sqlite3",
-        "py27-openssl",
+        "lang/python",
+        "py37-sqlite3",
+        "py37-openssl",
         "security/ca_root_nss",
         "git"
     ],


### PR DESCRIPTION
In this [commit](https://github.com/Tautulli/Tautulli/commit/141d043a6a4651054a1b24f07a9313407a14593c), an update break tautulli plugin.
Tautulli init script use "env python" but this doesn't work with lang/python27 package.