### PR TITLE
NAS-107920 / None / Move to latest version of Node.js

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -17,8 +17,8 @@
         "devel/gmake",
         "devel/git-lite",
         "lang/python3",
-        "www/node10",
-        "www/npm-node10",
+        "www/node",
+        "www/npm",
         "java/openjdk8-jre",
         "ftp/wget",
         "shells/bash"


### PR DESCRIPTION
The MineOS plugin doesn't install anymore on FreeNAS 11.3.  This PR fixes this. Reference JIRA bug NAS-107920

I'll test the same for the ix-plugin-hub community repo, but I'd like to keep the plugin working in 11.3-RELEASE for a bit longer.
Thank you!