### PR TITLE
NAS-107986 / None / Remove pkg categories as it causes issues for git-lite

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -11,17 +11,17 @@
         "nat_forwards": "tcp(8443:8443),tcp(25565:25565),tcp(25566:25566),tcp(25567:25567),tcp(25568:25568),tcp(25569:25569),tcp(25570:25570)"
     },
     "pkgs": [
-        "sysutils/py-rdiff-backup",
-        "sysutils/screen",
-        "net/rsync",
-        "devel/gmake",
-        "devel/git-lite",
-        "lang/python3",
-        "www/node",
-        "www/npm",
-        "java/openjdk8-jre",
-        "ftp/wget",
-        "shells/bash"
+        "py37-rdiff-backup",
+        "screen",
+        "rsync",
+        "gmake",
+        "git-lite",
+        "python37",
+        "node",
+        "npm",
+        "openjdk8-jre",
+        "wget",
+        "bash"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
The MineOS plugin installation currently fails due to an issue with the git-lite package.

The reason is that the git-lite package was converted from a "slave" port to a "flavor" of the `git` port.  As a result `pkg install devel/git-lite` no longer works for some reason, but `pkg install git-lite` without the category works fine.

More information in NAS-107986
