### PR TITLE
nextcloud: add ffmpeg to pkgs

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -9,6 +9,7 @@
         "nat_forwards": "tcp(80:8282)"
     },
     "pkgs": [
+        "ffmpeg",
         "nextcloud-php74",
         "php74-pecl-imagick-im7",
         "php74-bcmath",


### PR DESCRIPTION
ffmpeg is required to generate thumbnails for all types of videos