### PR TITLE
Add the PCNTL package for PHP as NextCloud requires this

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -13,6 +13,7 @@
         "php74-pecl-imagick-im7",
         "php74-bcmath",
         "php74-gmp",
+        "php74-pcntl",
         "nginx",
         "mysql57-server"
     ],


### PR DESCRIPTION
When running the OCC utility NextCloud complains that it's missing the PCNTL extension.