### PR TITLE
Update nextcloud.json

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -16,7 +16,7 @@
         "php74-gmp",
         "php74-pcntl",
         "nginx",
-        "mysql57-server"
+        "mysql80-server"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
NextCloud 21 will not support MySQL 5.7 and will require MySQL 8.0