### PR TITLE
Change Nextcloud `packagesite` to use `quarterly` package releases

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -22,7 +22,7 @@
         "py38-fail2ban",
         "py38-certbot"
     ],
-    "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
It appears PHP 7.4 is no longer included in FreeBSD 12.  This makes it impossible to install or upgrade the Nextcloud plugin on the latest version of TrueNAS.

PHP 7.4 is however, included in the quarterly releases.  Changing the `packagesite` attribute from `http://pkg.FreeBSD.org/${ABI}/latest` to `http://pkg.FreeBSD.org/${ABI}/quarterly` allows the plugin to install successfully as mentioned in #302 as a workaround.

Would it be possible to cut a release with this fix while a more permanent solution (such as moving the plugin to PHP 8.0+) is developed and tested?  This resolves #302 in the short term.