### PR TITLE
Update asigra version for 13

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -1,6 +1,6 @@
 {
     "name": "asigra",
-    "release": "12.2-RELEASE",
+    "release": "12.3-RELEASE",
     "artifact": "https://github.com/ix-plugin-hub/iocage-plugin-asigra.git",
     "pkgs": [
         "postgresql10-server",
@@ -27,7 +27,7 @@
         "vnet": 1,
         "dhcp": 1
     },
-    "packagesite": "http://download.truenas.com/plugins/asigra/stable/12.2-RELEASE",
+    "packagesite": "http://download.truenas.com/plugins/asigra/stable/12.3-RELEASE",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
This commit updates asigra version to 14.2.0.4. We are using 12.3-RELEASE temporarily until we have 13.1 available and around that time we can make the switch to 13.1 for stable/13.