### PR TITLE
NAS-115717 / None / Use release_3 packagesite for syncthing

### DIFF
--- a/syncthing.json
+++ b/syncthing.json
@@ -1,6 +1,6 @@
 {
     "name": "syncthing",
-    "release": "12.2-RELEASE",
+    "release": "12.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
     "official": false,
     "properties": {
@@ -12,7 +12,7 @@
         "ca_root_nss",
         "nginx"
     ],
-    "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/release_3",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
## Problem

Syncthing is not available anymore in `latest` and `quarterly` packagesites as it is not building right now due to build failures.

## Solution

Until the latest port is working, we temporarily shift to last quarter's packagesite so that syncthing plugin remains functional.