### PR TITLE
NAS-115838 / None / Use 13.0-RELEASE for minio/tarsnap plugins

### DIFF
--- a/minio.json
+++ b/minio.json
@@ -1,7 +1,7 @@
 {
     "name": "minio",
     "plugin_schema": "2",
-    "release": "12.2-RELEASE",
+    "release": "13.0-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-minio.git",
     "official": true,
     "properties": {

--- a/tarsnap.json
+++ b/tarsnap.json
@@ -1,7 +1,7 @@
 {
     "name": "Tarsnap",
     "plugin_schema": "2",
-    "release": "12.2-RELEASE",
+    "release": "13.0-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-tarsnap.git",
     "official": false,
     "properties": {


### PR DESCRIPTION
We still had plugins in 13 stable branch consuming 12.2 release.