### PR TITLE
add php80-phar

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -16,6 +16,7 @@
         "php80-gmp",
         "php80-pcntl",
         "php80-pecl-redis",
+        "php80-phar",
         "nginx",
         "mysql80-server",
         "redis",


### PR DESCRIPTION
This package is needed to run /usr/local/www/nextcloud/updater/updater.phar.
Without this, the command does run, returns 0 and does absolutely nothing, which is very confusing