### PR TITLE
NAS-117075 / 22.12 / Fix nextcloud installation

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -20,8 +20,8 @@
         "nginx",
         "mysql80-server",
         "redis",
-        "py38-fail2ban",
-        "py38-certbot"
+        "py39-fail2ban",
+        "py39-certbot"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
## Problem

Python 3.8 is not available anymore in the nextcloud plugin we install and hence python 3.8 packages fail to install

## Solution

Install Python 3.9 based packages in the nextcloud plugin