### PR TITLE
Update Syncthing to 13.1-RELEASE

### DIFF
--- a/syncthing.json
+++ b/syncthing.json
@@ -1,6 +1,6 @@
 {
     "name": "syncthing",
-    "release": "12.3-RELEASE",
+    "release": "13.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-syncthing.git",
     "official": false,
     "properties": {
@@ -12,7 +12,7 @@
         "ca_root_nss",
         "nginx"
     ],
-    "packagesite": "http://pkg.FreeBSD.org/${ABI}/release_3",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/release_1",
     "fingerprints": {
         "iocage-plugins": [
             {

--- a/syncthing.json
+++ b/syncthing.json
@@ -12,7 +12,7 @@
         "ca_root_nss",
         "nginx"
     ],
-    "packagesite": "http://pkg.FreeBSD.org/${ABI}/release_1",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
Update Syncthing to 13.1, wanted to go with release_1 repo but the package is not in there so quarterly should suffice.