### PR TITLE
NAS-118124 / None / Use 13.1-RELEASE for nextcloud

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,7 +1,7 @@
 {
     "name": "Nextcloud",
     "plugin_schema": "2",
-    "release": "13.0-RELEASE",
+    "release": "13.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
     "official": false,
     "properties": {


### PR DESCRIPTION
This commit fixes an issue where 13.0 release is not working with nextcloud anymore.
```
Running post_install.sh
ld-elf.so.1: /lib/libc.so.7: version FBSD_1.7 required by /usr/local/lib/libpython3.9.so.1.0 not found
```