### PR TITLE
NAS-121810 / None / Bump asigra release to 12.4

### DIFF
--- a/asigra.json
+++ b/asigra.json
@@ -1,6 +1,6 @@
 {
     "name": "asigra",
-    "release": "12.3-RELEASE",
+    "release": "12.4-RELEASE",
     "artifact": "https://github.com/ix-plugin-hub/iocage-plugin-asigra.git",
     "pkgs": [
         "postgresql10-server",


### PR DESCRIPTION
12.3-RELEASE is EOL and until 13.1-RELEASE has been made publicly available, idea is to bump to 12.4 till then so that new installations can work.