### PR TITLE
Bump Nextcloud to FreeBSD 13 and PHP 8.2 and switch to MariaDB

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,24 +1,22 @@
 {
     "name": "Nextcloud",
     "plugin_schema": "2",
-    "release": "12.2-RELEASE",
+    "release": "13.1-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
-    "official": false,
     "properties": {
-        "nat": 1,
-        "nat_forwards": "tcp(80:8282),tcp(443:8283)"
+        "dhcp": 1
     },
     "pkgs": [
         "ffmpeg",
-        "nextcloud-php80",
-        "php80-pecl-imagick-3.7.0_2",
-        "php80-bcmath",
-        "php80-gmp",
-        "php80-pcntl",
-        "php80-pecl-redis",
-        "php80-phar",
+        "nextcloud-php82",
+        "php82-pecl-imagick",
+        "php82-bcmath",
+        "php82-gmp",
+        "php82-pcntl",
+        "php82-pecl-redis",
+        "php82-phar",
         "nginx",
-        "mysql80-server",
+        "mariadb106-server",
         "redis",
         "py39-fail2ban",
         "py39-certbot"

--- a/nextcloud.json
+++ b/nextcloud.json
@@ -1,7 +1,7 @@
 {
     "name": "Nextcloud",
     "plugin_schema": "2",
-    "release": "13.1-RELEASE",
+    "release": "13.2-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-nextcloud.git",
     "properties": {
         "dhcp": 1


### PR DESCRIPTION
WARNING ⚠: You have to push with another PR I made or things will break !!!
Linked PR: [iocage-plugin-nextcloud #58](https://github.com/freenas/iocage-plugin-nextcloud/pull/58)

- Bump release to 13 because 12 is EOL  
[Source](https://endoflife.date/freebsd)
---
- Updated to php 8.2 because 8.0 is deprecated  
- Switch to MariaDB instead of MySQL for better performance  
[Following the recommendation on Nextcloud docs](https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html)
---
- Using DHCP instead of NAT for convenience.

This config (install/update) as been tested on my server under TrueNAS-13.0-U6.1